### PR TITLE
fix: make Zotero sync revision-consistent and atomic

### DIFF
--- a/E3_IMPLEMENTATION_PLAN.md
+++ b/E3_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,303 @@
+# E3 Implementation Plan — Zotero Sync Correctness
+
+Status: **plan only; awaiting review**  
+Branch: `codex/v2-e3`  
+Starting baseline: `2c276da8696618fcd4acd4b34eaf8b1b900219a4` (`v2-e2-baseline`)  
+Scope: ZotWatch repository only. This document does not modify production behavior.
+
+## 1. Goal and correctness invariant
+
+E3 makes the personal SQLite Zotero mirror correspond to one explicitly committed Zotero library revision. A successful sync has this invariant:
+
+> Every item change and deletion from the previously committed revision through the target revision has been observed, validated, and applied in one SQLite transaction; the persisted watermark names exactly that target revision.
+
+A failed sync leaves both the item rows and persisted watermark at their pre-run values. Full sync establishes the mirror from a complete remote snapshot. Incremental sync applies every change since the last successful revision. E3 does not attempt distributed exactly-once delivery: stable Zotero revisions, idempotent staging, and one local transaction provide the required guarantee.
+
+## 2. Current state machine and data flow
+
+Current production flow in `src/ingest_zotero_api.py` is:
+
+1. Initialize SQLite.
+2. Read `metadata.last_modified_version`, unless `full=True`, which sets the request watermark to `None`.
+3. Fetch `/users/{id}/items` page by page. Only the first page receives `If-Modified-Since-Version`; incremental requests do not send a `since` query parameter.
+4. Parse and immediately call `ProfileStorage.upsert_item()` for each item. Every upsert commits independently.
+5. Track the maximum `Last-Modified-Version` seen. A missing header currently becomes `0`.
+6. Catch `requests.RequestException` for item pagination, log it, and continue after any already committed partial writes.
+7. Request `/deleted` with the maximum revision just observed, rather than the revision committed before the run. A deletion request failure is also logged and ignored.
+8. Delete rows in another immediate commit.
+9. If any item was fetched, or the run is full, write the maximum revision in a final independent commit.
+
+`src/storage.py` exposes separately committing item, deletion, and metadata methods. There is no sync transaction or remote snapshot reconciliation. The existing metadata key `last_modified_version` is the only durable sync watermark.
+
+## 3. Confirmed defects and triggers
+
+E3 assigns stable regression identifiers to each intentional behavior change.
+
+| ID | Trigger | Current result | Required result |
+| --- | --- | --- | --- |
+| E3-SYNC-001 | A later item page fails after an earlier page was written | Earlier rows remain committed and the new watermark can still be committed | No item or watermark change; the run fails |
+| E3-SYNC-002 | Items response advances from `R0` to `Rt`, with tombstones after `R0` | `/deleted?since=Rt` can skip deletions in `(R0, Rt]` | Query deletions with the immutable starting revision `R0` |
+| E3-SYNC-003 | Full sync returns a set missing a local row | Full mode only upserts, leaving the stale row | Atomically reconcile local keys to the complete remote key set |
+| E3-SYNC-004 | Deleted endpoint fails after item pages succeeded | Item writes remain and deletion is skipped while the watermark may advance | Abort without any SQLite change |
+| E3-SYNC-005 | Zotero's library revision changes between pages or between items and deleted responses | Pages from different revisions can be combined and their maximum committed | Discard the staged attempt and restart; never combine revisions |
+| E3-SYNC-006 | A response lacks a valid `Last-Modified-Version`, has an invalid payload, or contains an invalid record | Missing revision can be interpreted as `0`; partial earlier records may already be committed | Treat the attempt as incomplete and leave SQLite unchanged |
+| E3-SYNC-007 | Incremental mode has a committed watermark | Conditional request is used, but no `since=R0` item query is sent | Request the delta since `R0`, while retaining the first-request no-op conditional |
+| E3-SYNC-008 | A page or item is replayed | It is counted and upserted repeatedly | Stage by item key; replay is idempotent and cannot regress the final object |
+
+Existing E0 observation labels map as follows: BUG-I1 → E3-SYNC-002, BUG-I2 → E3-SYNC-001/004, and BUG-I3 → E3-SYNC-003. BUG-I4, stale embedding retention after content change, belongs to computational state work and remains outside E3. The E3 release note will identify the changed cases instead of rewriting unrelated characterization output.
+
+## 4. Proposed state machine
+
+Each run separates remote acquisition from local commit.
+
+```text
+READ_COMMITTED
+  read R_start from SQLite
+  choose FULL when --full or R_start is absent; otherwise INCREMENTAL
+        |
+        v
+FETCH_ITEMS
+  fetch and validate pages into memory
+  establish R_target from first 200 response
+  require every page revision == R_target
+        |
+        +-- 304 in incremental mode --> NO_OP(R_start)
+        |
+        v
+FETCH_DELETIONS (incremental only)
+  GET /deleted?since=R_start
+  require response revision == R_target
+        |
+        v
+VALIDATE_COMPLETE
+  validate payloads, item keys/versions, links, duplicates, tombstones
+        |
+        +-- revision drift --> discard and retry bounded attempt
+        +-- any other failure --> fail, SQLite unchanged
+        |
+        v
+COMMIT_SQLITE
+  BEGIN IMMEDIATE
+  apply upserts
+  apply tombstones, or full snapshot reconciliation
+  write last_modified_version = R_target
+  COMMIT
+        |
+        +-- SQLite error --> ROLLBACK
+        v
+SUCCESS(R_target)
+```
+
+Network access never occurs inside the SQLite transaction. A run does not call the current individually committing storage methods while acquiring pages.
+
+### 4.1 Revision names
+
+- `R_start`: `metadata.last_modified_version` read before the attempt. It is the last successful committed library revision and remains immutable throughout all retries in one `run()` call.
+- `R_target`: the `Last-Modified-Version` from the first successful items response. It is the remote snapshot/delta revision the attempt intends to commit.
+- `R_observed`: the last validated response revision during acquisition. It may only equal `R_target`; a different value is revision drift, not a new maximum to absorb.
+- `R_commit`: the revision written with the item changes. It is assigned only inside the successful SQLite transaction and must equal `R_target`. On failure, durable `R_commit` remains `R_start`.
+
+`IngestStats` will expose these distinctions using optional `start_revision`, `target_revision`, `observed_revision`, and `committed_revision` fields. The existing `last_modified_version` field remains as a compatibility alias/value for the successful committed revision. It is never populated with an uncommitted observation.
+
+### 4.2 Stable response requirement
+
+Every 200 item page and the incremental deleted response must contain a parseable non-negative `Last-Modified-Version`. All values in one attempt must equal `R_target`. A higher or lower value means the library changed or the response set is inconsistent; the attempt is discarded.
+
+Revision drift receives a small bounded whole-attempt retry using the same `R_start`. The exact limit will be a named internal constant and covered by tests. Ordinary HTTP retry remains in `request_with_retry`; after that layer is exhausted, item/deletion failures propagate as a typed sync failure rather than multiplying requests with another whole-run network retry. A later CLI or workflow run starts again from the unchanged watermark.
+
+### 4.3 Incremental no-op
+
+The first incremental item request sends both the delta query `since=R_start` and `If-Modified-Since-Version: R_start`. A 304 means the library has not changed since the committed revision, so the run returns success at `R_start` without querying deletions or writing SQLite. This interpretation treats the conditional as library-version scoped, not item-list scoped.
+
+## 5. Full and incremental semantics
+
+### 5.1 Initial and explicit full sync
+
+If no watermark exists, incremental invocation is promoted to a full snapshot. Explicit `--full` also uses snapshot mode, regardless of an existing watermark.
+
+Snapshot mode:
+
+1. Fetches all pages for the current `/items` query scope without a conditional watermark.
+2. Requires one stable target revision across all pages, including an empty result.
+3. Parses the entire response set before touching SQLite.
+4. In one transaction, upserts all remote items, removes every local item key absent from the remote snapshot, and writes `R_target`.
+
+The full-snapshot domain remains the existing ZotWatch `/items` endpoint/query scope; E3 will not introduce new Zotero item-type, collection, trash, or write-back policy. Full sync does not need `/deleted`: set reconciliation already determines the final mirror and avoids making completeness depend on historical tombstone retention.
+
+An empty remote snapshot is valid only after a successful response carrying a valid target revision. It removes all local item rows inside the final transaction. A network failure before that point cannot empty the local database.
+
+### 5.2 Incremental sync
+
+With committed `R_start`, incremental mode:
+
+1. Fetches item changes with `since=R_start` and a first-request conditional header.
+2. Follows pagination links while validating every response against `R_target`.
+3. Fetches `/deleted?since=R_start`, never `R_target` or a page maximum.
+4. Requires the deleted response revision to match `R_target`.
+5. Atomically applies upserts, then tombstones, then `last_modified_version=R_target`.
+
+If a key appears in both changed items and tombstones for the same stable revision, deletion wins because it describes the final absence. Deleting an already absent key is a no-op.
+
+## 6. Acquisition and validation boundary
+
+Remote data is staged in memory as a mapping keyed by Zotero item key plus a set of deleted keys. This is the smallest design that prevents partial commits without keeping a write transaction open during network operations. A staging table is not planned for E3 because it would add schema lifecycle and recovery states without improving the single-process correctness boundary. If real library sizes later make memory use unacceptable, a durable or temporary staging design can replace the collector behind the same commit contract.
+
+Validation occurs before SQLite mutation:
+
+- response bodies have the expected list/object shape;
+- revision headers are present, numeric, non-negative, and stable;
+- every item has a non-empty string key and valid non-negative item version before `ZoteroItem` projection;
+- tombstones are non-empty string keys;
+- pagination next links cannot form a URL cycle;
+- duplicate/replayed items with the same key select the highest item version;
+- identical replays are ignored;
+- conflicting payloads at the same item version fail the attempt instead of using response order as an implicit tie-breaker.
+
+Malformed individual records fail the whole attempt. Skipping one bad object while advancing the library watermark would claim a complete mirror and make that object unreachable on the next incremental sync. Quarantine/degraded-watermark support is not part of E3.
+
+The staged data contains normalized `ZoteroItem` objects and precomputed content hashes. It must not include API credentials in exceptions, logs, or returned stats.
+
+## 7. SQLite transaction strategy
+
+`ProfileStorage` will gain one sync-specific atomic apply operation; existing general-purpose methods and schema remain available for compatibility.
+
+The operation will:
+
+1. Start `BEGIN IMMEDIATE` only after all remote reads and validation succeed.
+2. Upsert staged items with the existing item-field projection and content hash behavior.
+3. For incremental mode, remove staged tombstone keys in bounded batches.
+4. For full mode, read current local keys inside the transaction, compute stale keys against the staged remote set, and remove them in bounded batches.
+5. Write `metadata.last_modified_version = R_target` using the same connection and transaction.
+6. Commit once. Any exception rolls back item rows, deletions, and metadata together.
+
+Bounded deletes avoid SQLite parameter limits. The method returns actual inserted/changed/removed counts so replayed or unknown keys do not inflate success statistics.
+
+E3 retains the existing `last_modified_version` metadata key and tightens its meaning to “last successfully committed Zotero library revision.” Existing databases therefore require no schema migration. Missing metadata triggers snapshot establishment. An invalid stored value produces a clear error; explicit full sync can recover by ignoring the invalid starting value and atomically replacing it only after a complete snapshot.
+
+Embedding columns remain untouched by E3 upserts, matching the current storage behavior. Fixing or rebuilding computational state after source content changes remains E4 scope.
+
+## 8. Failure, retry, and idempotency semantics
+
+| Failure point | SQLite effect | Watermark effect | Retry behavior |
+| --- | --- | --- | --- |
+| First or later items page fails after HTTP retries | None | Remains `R_start` | Next run reads the same delta/full snapshot |
+| Deleted endpoint fails | None | Remains `R_start` | Next run repeats items and deletions from `R_start` |
+| Remote revision changes during pagination | None | Remains `R_start` | Discard staging and make a bounded fresh attempt |
+| Malformed header, page, item, or tombstone | None | Remains `R_start` | Fail visibly; retry after remote/input correction |
+| Pagination URL cycle | None | Remains `R_start` | Fail visibly instead of looping |
+| SQLite apply fails | Full rollback | Remains `R_start` | Next run replays the same staged remote interval |
+| Process exits during acquisition | None | Remains `R_start` | Next run starts cleanly |
+| Process/SQLite failure during transaction | SQLite atomic rollback/recovery | Item rows and watermark remain mutually consistent | Next run starts from durable `R_start` |
+
+Replaying a completed delta from an old test response is also idempotent: item upsert, tombstone deletion, and the same metadata replacement produce the same mirror. The real client normally requests only changes after the committed revision.
+
+The ingestor will stop swallowing terminal request failures. It will raise a domain-specific exception so `profile`/`watch` fail instead of continuing into profile/ranking with an incomplete mirror. This is an intentional E3 correctness change and will be called out in release notes.
+
+## 9. Compatibility
+
+E3 preserves:
+
+- `ZOTERO_API_KEY` and `ZOTERO_USER_ID` names and their existing settings lookup;
+- the `zotwatch profile/watch` and `python -m src.cli profile/watch` entry points;
+- `--full` and `--weekly` call compatibility;
+- the existing SQLite `items` table and `metadata.last_modified_version` key;
+- already stored user items and credentials; no Zotero reauthorization is needed;
+- ranking, scoring, public candidate, output, config/provider registry, and non-sync E0/E1/E2 behavior.
+
+Existing callers may continue reading `IngestStats.fetched`, `updated`, `removed`, and `last_modified_version`. New revision fields make the commit state explicit. Tests that intentionally assert BUG-I1/I2/I3 will be changed only alongside numbered E3 regression coverage. Original E0 golden files and unrelated fixtures will not be regenerated.
+
+Compatibility does not preserve silent success after an incomplete sync, partial page commits, skipped tombstones, or stale rows after a full snapshot. Those are the named correctness fixes.
+
+## 10. Expected modified files
+
+Production files expected after plan approval:
+
+- `src/ingest_zotero_api.py`: typed sync results/errors, revision-aware page/deletion responses, staged acquisition, stability validation, full/incremental state machine.
+- `src/storage.py`: one atomic sync apply method and bounded deletion/reconciliation helpers; no table redesign.
+- `src/cli.py`: only if needed to log explicit revision fields while preserving command signatures and nonzero failure propagation.
+
+Test and documentation files expected:
+
+- `tests/test_zotero_sync_e3.py` (new): focused state-machine, transaction, failure, retry, drift, malformed-record, and idempotency regressions.
+- `tests/test_ingestion_dedupe.py`: replace only BUG-I1/I2/I3 observation assertions superseded by numbered E3 cases; retain unrelated mapping/dedupe and BUG-I4 coverage.
+- `tests/test_pipeline_http.py`: update synthetic sync response headers/queries as required by the stricter protocol, without changing ranking/output expectations.
+- `tests/helpers.py` only if the synthetic response helper needs explicit headers/URLs for the new cases.
+- `tests/README.md`: map old BUG-I identifiers to E3 regression IDs and distinguish the remaining BUG-I4 observation.
+- `docs/E3_SYNC_CORRECTNESS.md` (new): revision contract, operational recovery, intentional behavior changes, and release note.
+- `.github/workflows/characterization.yml` and/or `.github/workflows/packaging.yml` only if a static E3 gate command is needed; no new service, secret, or network dependency.
+
+No changes are planned under `zotwatch/config`, `zotwatch/providers`, ranking/candidate modules, harvester, workspace template, web, or reusable workflow code.
+
+## 11. Regression test matrix
+
+All HTTP tests use synthetic responses and real temporary SQLite databases. No test contacts Zotero.
+
+| Case | Mode/setup | Expected assertions | Regression ID |
+| --- | --- | --- | --- |
+| Initial full sync | No watermark, empty/local-preloaded DB | Complete snapshot present; stale local rows absent; target revision committed atomically | E3-SYNC-003 |
+| Explicit full sync | Existing watermark/items | Remote set exactly replaces mirror set; existing DB schema remains usable | E3-SYNC-003 |
+| No-op sync | `R_start`, first response 304 | No deleted call, no item write, committed revision remains `R_start` | protocol contract |
+| One added item | Delta since `R_start` | New row and `R_target` committed together | core incremental |
+| One modified item | Existing key with newer item version | Source fields/hash updated; revision committed; embedding behavior unchanged | core incremental / BUG-I4 retained |
+| One deleted item | Tombstone after `R_start` | Deleted request uses `R_start`; row removed with `R_target` | E3-SYNC-002 |
+| Add + modify + delete | One stable revision | All three effects and watermark commit in one transaction; delete wins on key overlap | E3-SYNC-002 |
+| Multi-page sync | Two or more stable pages | Every next link fetched; one final SQLite transaction | core pagination |
+| Second/middle page failure | First page valid, later page exhausts retry | Exception; item rows and watermark byte/semantically unchanged | E3-SYNC-001 |
+| Deletion endpoint failure | All item pages valid | Exception; no staged items committed; watermark unchanged | E3-SYNC-004 |
+| Retry after failed sync | Repeat after page/deletion failure | Starts from original watermark and commits complete result exactly once | E3-SYNC-001/004 |
+| Full rebuild removes stale rows | Remote omits local key | Missing key removed only in successful final transaction | E3-SYNC-003 |
+| Duplicate/replayed page | Same item appears more than once | One final row, deterministic highest version, stable counts | E3-SYNC-008 |
+| Pagination cycle | `next` repeats a visited URL | Visible failure, no SQLite change | E3-SYNC-006 |
+| Remote revision changes mid-sync | Later page or deleted response revision differs | Attempt discarded; fresh attempt succeeds, or bounded retry fails with no DB change | E3-SYNC-005 |
+| Malformed individual item | One valid and one bad record | Whole attempt fails; valid sibling is not partially committed | E3-SYNC-006 |
+| Malformed payload/header | Wrong JSON shape, absent/invalid revision | Visible failure; watermark and rows unchanged | E3-SYNC-006 |
+| Empty full snapshot | Valid empty 200 response | Local item rows removed and target committed; a failed empty fetch never clears DB | E3-SYNC-003/006 |
+| SQLite failure before watermark | Inject failure during apply | Entire transaction rolls back, including earlier upserts/deletes | transaction contract |
+| Legacy DB compatibility | Existing E2-era schema and watermark | Reads watermark and syncs without migration or reauthorization | compatibility |
+
+For the first implementation commit, the new correctness tests are added before production changes and are expected to fail against `v2-e2-baseline`. They will not be marked `xfail` or satisfied by changing golden files. The PR description will record which cases fail on the old implementation and pass after each fix.
+
+## 12. Test gates
+
+After each implementation commit, run the focused sync tests first. Before opening the PR, run:
+
+1. New E3 sync suite and the existing ingestion/pipeline suites.
+2. Full E0 characterization suite in its pinned environment.
+3. E1 packaging/install gate, including wheel and editable installs.
+4. E2 config/schema/provider registry tests and offline CLI validation.
+5. A diff/hash check proving original E0 golden files and original E0 fixture files were not modified. E2's separate `tests/fixtures/config-v2/` additions remain intact.
+
+No failing remote gate will be resolved by mass-updating golden expected output. Environment-only differences will be diagnosed before expected behavior changes.
+
+## 13. Commit and PR boundaries
+
+This plan is the only change in the current commit. After approval, E3 implementation will use reviewable commits in this order:
+
+1. `test(sync): define E3 correctness regressions`  
+   Add the failing regression matrix and test helpers. Record the intentional red result against `v2-e2-baseline`; do not use xfail or modify production code.
+2. `fix(sync): stage a revision-consistent Zotero delta`  
+   Add `since=R_start`, typed page/deletion results, header/payload validation, duplicate handling, stable-revision checks, bounded drift restart, and propagated failures.
+3. `fix(storage): commit Zotero mirror updates atomically`  
+   Add the single SQLite apply transaction, full snapshot reconciliation, tombstone ordering, rollback behavior, and compatible watermark handling.
+4. `docs(sync): record E3 behavior changes and verification`  
+   Update the characterization map/release note, any narrowly required CLI logging and CI gate, and final local/remote evidence.
+
+If the natural dependency between the state machine and storage makes commits 2 and 3 temporarily fail, each commit will still remain structurally reviewable and the final branch will be green. Production sync, tests, and docs stay in one E3 PR; no harvester, candidate, ranking, AI, state-artifact, workflow-template, or Cloudflare changes enter it.
+
+## 14. Rollback strategy
+
+E3 introduces no irreversible schema migration. Rolling back the E3 code to `v2-e2-baseline` leaves the existing `items` and `metadata` tables readable. The tightened watermark uses the same key and integer representation.
+
+If E3 has completed a sync before rollback, the database contains a more accurate mirror at the committed revision. Old code can read it. Because old code has unsafe failure semantics, the operational rollback procedure is:
+
+1. Stop scheduled sync during rollback.
+2. Pin the engine/caller to `v2-e2-baseline` only if needed to restore execution.
+3. Preserve the SQLite file for diagnosis.
+4. After restoring E3 or a follow-up fix, run an explicit full sync to re-establish a complete remote snapshot.
+
+The E3 code path itself rolls back failed SQLite transactions automatically. No automatic downgrade, database deletion, credential change, Zotero reauthorization, or golden rewrite is part of rollback.
+
+## 15. Explicit exclusions
+
+E3 will not implement profile incremental rebuild, embedding/FAISS invalidation or persistence, clustering, AI, recommendation/scoring changes, public candidate changes, reusable workflows, workspace-template changes, Cloudflare control-plane work, Zotero OAuth, Zotero write-back changes, or harvester changes.
+

--- a/E3_IMPLEMENTATION_PLAN.md
+++ b/E3_IMPLEMENTATION_PLAN.md
@@ -43,6 +43,7 @@ E3 assigns stable regression identifiers to each intentional behavior change.
 | E3-SYNC-006 | A response lacks a valid `Last-Modified-Version`, has an invalid payload, or contains an invalid record | Missing revision can be interpreted as `0`; partial earlier records may already be committed | Treat the attempt as incomplete and leave SQLite unchanged |
 | E3-SYNC-007 | Incremental mode has a committed watermark | Conditional request is used, but no `since=R0` item query is sent | Request the delta since `R0`, while retaining the first-request no-op conditional |
 | E3-SYNC-008 | A page or item is replayed | It is counted and upserted repeatedly | Stage by item key; replay is idempotent and cannot regress the final object |
+| E3-SYNC-009 | An item moves to trash or is restored | Default `/items` excludes trash, so a trash transition can leave a stale local row while the watermark advances | Use `includeTrashed=1` as the transport domain and project `data.deleted` into the non-trash local mirror domain |
 
 Existing E0 observation labels map as follows: BUG-I1 → E3-SYNC-002, BUG-I2 → E3-SYNC-001/004, and BUG-I3 → E3-SYNC-003. BUG-I4, stale embedding retention after content change, belongs to computational state work and remains outside E3. The E3 release note will identify the changed cases instead of rewriting unrelated characterization output.
 
@@ -99,6 +100,14 @@ Network access never occurs inside the SQLite transaction. A run does not call t
 
 `IngestStats` will expose these distinctions using optional `start_revision`, `target_revision`, `observed_revision`, and `committed_revision` fields. The existing `last_modified_version` field remains as a compatibility alias/value for the successful committed revision. It is never populated with an uncommitted observation.
 
+The legacy counter fields retain their observable meaning wherever it already exists:
+
+- `fetched` counts valid item records observed from the transport, including replayed pages and, after E3, explicit trash-state records;
+- `updated` counts valid non-trashed item records accepted for local upsert, including unchanged and replayed records, so historical no-trash runs continue to report one `updated` per fetched item;
+- `removed` counts unique removal intents produced by permanent tombstones, trash transitions, and full-snapshot stale-key reconciliation.
+
+Atomic apply also returns new `applied_inserted`, `applied_changed`, and `applied_removed` counters for actual SQLite row mutations. A replay or unchanged item can therefore increment legacy `updated` while leaving `applied_changed` at zero. An unknown tombstone can increment legacy `removed` while leaving `applied_removed` at zero. These semantics will have dedicated regressions and release-note documentation; E3 does not silently redefine `updated` to mean actual changed rows.
+
 ### 4.2 Stable response requirement
 
 Every 200 item page and the incremental deleted response must contain a parseable non-negative `Last-Modified-Version`. All values in one attempt must equal `R_target`. A higher or lower value means the library changed or the response set is inconsistent; the attempt is discarded.
@@ -111,42 +120,62 @@ The first incremental item request sends both the delta query `since=R_start` an
 
 ## 5. Full and incremental semantics
 
-### 5.1 Initial and explicit full sync
+### 5.1 Transport domain and local mirror domain
+
+Zotero's official API documentation states that `/items` excludes trashed items by default, while the official sync sequence requests item changes with `includeTrashed=1`. Zotero Data Server API v3 serializes a trashed item directly as `data.deleted: 1`; after restore the `deleted` property is absent. E3 uses this field only: present `1`/`true` means trashed, absence means active, and any other present value is malformed. It does not infer trash from title, item type, endpoint source, or missing membership.
+
+References used to fix the contract:
+
+- [Zotero Web API v3 syncing sequence](https://www.zotero.org/support/dev/web_api/v3/syncing)
+- [Zotero Web API item endpoint and `includeTrashed` semantics](https://www.zotero.org/support/dev/web_api/v3/basics)
+- [Official Data Server API v3 include-trash and restore tests](https://github.com/zotero/dataserver/blob/476ed12c18cbd431170346702882d091710f5f61/tests/remote/tests/3/item.test.js#L2089-L2215)
+
+This creates two explicit domains:
+
+- **Synchronization transport domain:** both full and incremental `/items` requests use `includeTrashed=1`, so trash and restore are observable versioned item changes.
+- **ZotWatch local mirror domain:** only active items are stored and used by profile building. Trashed items are staged as removal intents, never projected into the local item table.
+
+In an incremental delta, `data.deleted: 1` removes the local row and an active response for a previously trashed key restores it by normal upsert. In a full snapshot, only active remote keys form the authoritative mirror set; trashed remote keys are excluded, so full and incremental runs converge on the same local domain.
+
+### 5.2 Initial and explicit full sync
 
 If no watermark exists, incremental invocation is promoted to a full snapshot. Explicit `--full` also uses snapshot mode, regardless of an existing watermark.
 
 Snapshot mode:
 
-1. Fetches all pages for the current `/items` query scope without a conditional watermark.
+1. Fetches all pages with `includeTrashed=1` and without a conditional watermark.
 2. Requires one stable target revision across all pages, including an empty result.
 3. Parses the entire response set before touching SQLite.
-4. In one transaction, upserts all remote items, removes every local item key absent from the remote snapshot, and writes `R_target`.
+4. Partitions active and trashed items using `data.deleted`.
+5. In one transaction, upserts active remote items, removes every local item key absent from the active remote snapshot, and writes `R_target`.
 
-The full-snapshot domain remains the existing ZotWatch `/items` endpoint/query scope; E3 will not introduce new Zotero item-type, collection, trash, or write-back policy. Full sync does not need `/deleted`: set reconciliation already determines the final mirror and avoids making completeness depend on historical tombstone retention.
+The product-visible full-snapshot domain remains the existing non-trash ZotWatch `/items` domain. `includeTrashed=1` expands only the synchronization transport so trash state is explicit; it does not add trashed records to SQLite/profile. E3 will not introduce new item-type, collection, or write-back policy. Full sync does not need `/deleted`: active-set reconciliation already determines the final mirror and avoids making completeness depend on historical tombstone retention.
 
 An empty remote snapshot is valid only after a successful response carrying a valid target revision. It removes all local item rows inside the final transaction. A network failure before that point cannot empty the local database.
 
-### 5.2 Incremental sync
+### 5.3 Incremental sync
 
 With committed `R_start`, incremental mode:
 
-1. Fetches item changes with `since=R_start` and a first-request conditional header.
+1. Fetches item changes with `since=R_start`, `includeTrashed=1`, and a first-request conditional header.
 2. Follows pagination links while validating every response against `R_target`.
 3. Fetches `/deleted?since=R_start`, never `R_target` or a page maximum.
 4. Requires the deleted response revision to match `R_target`.
-5. Atomically applies upserts, then tombstones, then `last_modified_version=R_target`.
+5. Partitions active item upserts from `data.deleted` trash removals.
+6. Atomically applies active upserts, then trash/permanent-delete removals, then `last_modified_version=R_target`.
 
 If a key appears in both changed items and tombstones for the same stable revision, deletion wins because it describes the final absence. Deleting an already absent key is a no-op.
 
 ## 6. Acquisition and validation boundary
 
-Remote data is staged in memory as a mapping keyed by Zotero item key plus a set of deleted keys. This is the smallest design that prevents partial commits without keeping a write transaction open during network operations. A staging table is not planned for E3 because it would add schema lifecycle and recovery states without improving the single-process correctness boundary. If real library sizes later make memory use unacceptable, a durable or temporary staging design can replace the collector behind the same commit contract.
+Remote data is staged in memory as a mapping keyed by Zotero item key, including its explicit active/trashed state, plus a set of permanent-deletion tombstones. This is the smallest design that prevents partial commits without keeping a write transaction open during network operations. A staging table is not planned for E3 because it would add schema lifecycle and recovery states without improving the single-process correctness boundary. If real library sizes later make memory use unacceptable, a durable or temporary staging design can replace the collector behind the same commit contract.
 
 Validation occurs before SQLite mutation:
 
 - response bodies have the expected list/object shape;
 - revision headers are present, numeric, non-negative, and stable;
 - every item has a non-empty string key and valid non-negative item version before `ZoteroItem` projection;
+- `data.deleted` is absent for active items or the documented `1`/`true` value for trashed items; another present value fails validation;
 - tombstones are non-empty string keys;
 - pagination next links cannot form a URL cycle;
 - duplicate/replayed items with the same key select the highest item version;
@@ -164,8 +193,8 @@ The staged data contains normalized `ZoteroItem` objects and precomputed content
 The operation will:
 
 1. Start `BEGIN IMMEDIATE` only after all remote reads and validation succeed.
-2. Upsert staged items with the existing item-field projection and content hash behavior.
-3. For incremental mode, remove staged tombstone keys in bounded batches.
+2. Upsert staged active items with the existing item-field projection and content hash behavior.
+3. For incremental mode, remove staged trash-transition and permanent-tombstone keys in bounded batches.
 4. For full mode, read current local keys inside the transaction, compute stale keys against the staged remote set, and remove them in bounded batches.
 5. Write `metadata.last_modified_version = R_target` using the same connection and transaction.
 6. Commit once. Any exception rolls back item rows, deletions, and metadata together.
@@ -240,6 +269,9 @@ All HTTP tests use synthetic responses and real temporary SQLite databases. No t
 | One added item | Delta since `R_start` | New row and `R_target` committed together | core incremental |
 | One modified item | Existing key with newer item version | Source fields/hash updated; revision committed; embedding behavior unchanged | core incremental / BUG-I4 retained |
 | One deleted item | Tombstone after `R_start` | Deleted request uses `R_start`; row removed with `R_target` | E3-SYNC-002 |
+| Existing item moved to trash | Changed item has `data.deleted: 1` | Request uses `includeTrashed=1`; local row removed and `R_target` committed | E3-SYNC-009 |
+| Trashed item restored | Changed item no longer has `data.deleted` | Active item is upserted into the local mirror and `R_target` committed | E3-SYNC-009 |
+| Full sync with active and trashed items | Full transport includes both states | SQLite contains exactly the active set; result agrees with incremental transitions | E3-SYNC-003/009 |
 | Add + modify + delete | One stable revision | All three effects and watermark commit in one transaction; delete wins on key overlap | E3-SYNC-002 |
 | Multi-page sync | Two or more stable pages | Every next link fetched; one final SQLite transaction | core pagination |
 | Second/middle page failure | First page valid, later page exhausts retry | Exception; item rows and watermark byte/semantically unchanged | E3-SYNC-001 |
@@ -247,6 +279,7 @@ All HTTP tests use synthetic responses and real temporary SQLite databases. No t
 | Retry after failed sync | Repeat after page/deletion failure | Starts from original watermark and commits complete result exactly once | E3-SYNC-001/004 |
 | Full rebuild removes stale rows | Remote omits local key | Missing key removed only in successful final transaction | E3-SYNC-003 |
 | Duplicate/replayed page | Same item appears more than once | One final row, deterministic highest version, stable counts | E3-SYNC-008 |
+| Legacy vs applied stats | Unchanged/replayed item and unknown deletion | `updated` preserves per-record legacy count; new applied counters report actual row mutations | stats compatibility |
 | Pagination cycle | `next` repeats a visited URL | Visible failure, no SQLite change | E3-SYNC-006 |
 | Remote revision changes mid-sync | Later page or deleted response revision differs | Attempt discarded; fresh attempt succeeds, or bounded retry fails with no DB change | E3-SYNC-005 |
 | Malformed individual item | One valid and one bad record | Whole attempt fails; valid sibling is not partially committed | E3-SYNC-006 |
@@ -300,4 +333,3 @@ The E3 code path itself rolls back failed SQLite transactions automatically. No 
 ## 15. Explicit exclusions
 
 E3 will not implement profile incremental rebuild, embedding/FAISS invalidation or persistence, clustering, AI, recommendation/scoring changes, public candidate changes, reusable workflows, workspace-template changes, Cloudflare control-plane work, Zotero OAuth, Zotero write-back changes, or harvester changes.
-

--- a/E3_IMPLEMENTATION_PLAN.md
+++ b/E3_IMPLEMENTATION_PLAN.md
@@ -1,6 +1,6 @@
 # E3 Implementation Plan — Zotero Sync Correctness
 
-Status: **plan only; awaiting review**  
+Status: **approved; implementation follows this reviewed boundary**
 Branch: `codex/v2-e3`  
 Starting baseline: `2c276da8696618fcd4acd4b34eaf8b1b900219a4` (`v2-e2-baseline`)  
 Scope: ZotWatch repository only. This document does not modify production behavior.

--- a/docs/E3_SYNC_CORRECTNESS.md
+++ b/docs/E3_SYNC_CORRECTNESS.md
@@ -1,6 +1,6 @@
 # E3 Zotero sync correctness contract and release note
 
-Status: implementation complete locally; remote PR gates pending. E3 starts from `v2-e2-baseline` (`2c276da8696618fcd4acd4b34eaf8b1b900219a4`).
+Status: implementation complete in [PR #6](https://github.com/Yorks0n/ZotWatch/pull/6); local and remote gates passed. E3 starts from `v2-e2-baseline` (`2c276da8696618fcd4acd4b34eaf8b1b900219a4`).
 
 ## Mirror invariant
 
@@ -80,6 +80,8 @@ E3 adds no irreversible schema migration. Code can be pinned back to `v2-e2-base
 
 ## Regression evidence
 
-The tests-only commit failed against the unchanged E2 production tree with **25 failed, exit code 1**; see [E3_RED_BASELINE.md](../tests/E3_RED_BASELINE.md). The final verification record will be added after E0/E1/E2/E3 local and remote gates complete. Original E0 goldens are not regenerated.
+The tests-only commit failed against the unchanged E2 production tree with **25 failed, exit code 1**; see [E3_RED_BASELINE.md](../tests/E3_RED_BASELINE.md). Original E0 goldens were not regenerated.
 
-After implementation, the focused sync/ingestion/pipeline set passes **46 tests**. The local forced packaging run builds a fresh sdist and wheel, invokes both wheel and editable engines outside the source checkout, runs E0/E1/E2/E3 together, and reports **167 passed, 0 skipped**. Remote PR evidence remains pending until the branch is pushed.
+After implementation, the focused sync/ingestion/pipeline set passes **46 tests**. Two consecutive local characterization runs each report **151 passed** with the 16 installation-only cases skipped by design. The local forced packaging run builds a fresh sdist and wheel, invokes both wheel and editable engines outside the source checkout, runs E0/E1/E2/E3 together, and reports **167 passed, 0 skipped**.
+
+The first complete PR head passed both remote workflows: [E0 characterization](https://github.com/Yorks0n/ZotWatch/actions/runs/34472415891) and [E1 packaging and E2 config](https://github.com/Yorks0n/ZotWatch/actions/runs/34472415895), including installed-engine and immutable-E0 checks. A final docs-only evidence commit is subject to the same PR checks.

--- a/docs/E3_SYNC_CORRECTNESS.md
+++ b/docs/E3_SYNC_CORRECTNESS.md
@@ -1,0 +1,85 @@
+# E3 Zotero sync correctness contract and release note
+
+Status: implementation complete locally; remote PR gates pending. E3 starts from `v2-e2-baseline` (`2c276da8696618fcd4acd4b34eaf8b1b900219a4`).
+
+## Mirror invariant
+
+`metadata.last_modified_version` is the last Zotero library revision for which ZotWatch successfully acquired and committed a complete local mirror update. Item rows and this watermark change in one SQLite transaction. If acquisition, validation, revision stability, deletion retrieval, or SQLite apply fails, the prior rows and watermark remain durable.
+
+The four revision values reported by ingestion are:
+
+- `start_revision`: the durable watermark read before the run;
+- `target_revision`: the revision established by the first versioned items response;
+- `observed_revision`: the matching revision last observed after all required pages and deleted data;
+- `committed_revision`: the target written atomically with the mirror update.
+
+On success, target, observed, committed, and legacy `last_modified_version` identify the same revision. An incremental 304 is a successful no-op at `start_revision`.
+
+## Transport and local domains
+
+Both full and incremental item reads use `includeTrashed=1`. This follows Zotero's [official sync sequence](https://www.zotero.org/support/dev/web_api/v3/syncing) and lets the engine observe move-to-trash and restore transitions. The API's direct editable JSON state is used: `data.deleted: 1` means trashed; after restore the property is absent. Zotero's official Data Server tests exercise the same [include-trash and restore representation](https://github.com/zotero/dataserver/blob/476ed12c18cbd431170346702882d091710f5f61/tests/remote/tests/3/item.test.js#L2089-L2215).
+
+The transport domain may contain trash, but the ZotWatch local mirror and profile domain contains active items only:
+
+- moving an existing item to trash removes its local mirror row;
+- restoring an item upserts it into the mirror again;
+- full sync reconciles SQLite against only the active keys from the complete transport snapshot;
+- permanent deletion tombstones and trash transitions both remove rows, with removal winning if the same key is also present as an active update.
+
+## Full and incremental behavior
+
+When no watermark exists, a normal invocation establishes a full snapshot. Explicit `--full` does the same while retaining the old CLI contract. All pages are staged and validated before SQLite changes. Full sync does not clear the database before network access and does not depend on historical deletion tombstones; it atomically removes local keys absent from the completed active remote snapshot.
+
+Incremental item retrieval sends `since=<start_revision>`, `includeTrashed=1`, and the existing first-request `If-Modified-Since-Version`. The deleted endpoint always receives the same immutable start revision. Every 200 item page and deleted response must report the target `Last-Modified-Version`. If Zotero changes revision during acquisition, the staging area is discarded and retrieval restarts from the original durable watermark, up to the bounded retry limit.
+
+Malformed payloads, missing/invalid revision headers, invalid item keys/versions/trash markers, conflicting same-version duplicates, and pagination cycles fail the whole attempt. Valid records are not partially committed around an invalid sibling.
+
+## SQLite boundary
+
+Remote data is staged in memory; no database write transaction is held across network requests. After completeness checks, `ProfileStorage.apply_zotero_sync()` executes:
+
+1. `BEGIN IMMEDIATE`;
+2. active-item inserts and changed-row updates;
+3. trash/tombstone deletion, or full active-key reconciliation;
+4. `metadata.last_modified_version` replacement;
+5. one commit, with rollback on any exception.
+
+The existing tables and metadata key are unchanged, so current SQLite files need no schema migration. Explicit full sync can recover from an invalid stored watermark only after a complete remote snapshot. The embedding column is intentionally preserved; embedding invalidation and FAISS/profile state remain outside E3.
+
+## Stats compatibility
+
+Legacy fields keep their established operational meaning:
+
+- `fetched`: valid transport item records observed, including replayed and trash records;
+- `updated`: valid active item records accepted for upsert, including unchanged/replayed records;
+- `removed`: unique removal intents for incremental runs and reconciled local rows for full runs.
+
+New fields report actual SQLite mutations: `applied_inserted`, `applied_changed`, and `applied_removed`. An unchanged replay can therefore report `updated=1` and `applied_changed=0`; an unknown tombstone can report `removed=1` and `applied_removed=0`.
+
+## Intentional behavior changes
+
+| ID | Change |
+| --- | --- |
+| E3-SYNC-001 | Middle-page failure now fails the run without partial rows or watermark advancement. |
+| E3-SYNC-002 | Deleted data is requested from the last committed revision, fixing BUG-I1. |
+| E3-SYNC-003 | Full sync removes stale and trashed local rows after a complete snapshot, fixing BUG-I3. |
+| E3-SYNC-004 | Deleted-endpoint failure now aborts the whole staged attempt. |
+| E3-SYNC-005 | Mixed remote revisions are discarded and retried instead of taking their maximum. |
+| E3-SYNC-006 | Missing revisions and malformed pages/records are fatal to the attempt. |
+| E3-SYNC-007 | Incremental items use the required `since` revision. |
+| E3-SYNC-008 | Replayed items are staged deterministically by key/version and applied idempotently. |
+| E3-SYNC-009 | Trash and restore transitions are observed through `includeTrashed=1` while trash remains excluded from the product mirror. |
+
+Terminal network failures now propagate as `ZoteroSyncError`; `profile` and `watch` stop instead of continuing with an incomplete mirror. This is intentional. Zotero API key/user ID names, authorization, installed and legacy CLI entry points, existing SQLite schema, and non-sync behavior remain compatible.
+
+## Recovery and rollback
+
+A failed run can be retried normally because its durable start revision did not move. If a stored watermark is malformed or the mirror is suspect, run an explicit full sync; the old mirror remains until the complete replacement is ready.
+
+E3 adds no irreversible schema migration. Code can be pinned back to `v2-e2-baseline` while preserving the database for diagnosis, though the E2 sync path has the correctness defects listed above. After restoring E3, run full sync to re-establish the invariant.
+
+## Regression evidence
+
+The tests-only commit failed against the unchanged E2 production tree with **25 failed, exit code 1**; see [E3_RED_BASELINE.md](../tests/E3_RED_BASELINE.md). The final verification record will be added after E0/E1/E2/E3 local and remote gates complete. Original E0 goldens are not regenerated.
+
+After implementation, the focused sync/ingestion/pipeline set passes **46 tests**. The local forced packaging run builds a fresh sdist and wheel, invokes both wheel and editable engines outside the source checkout, runs E0/E1/E2/E3 together, and reports **167 passed, 0 skipped**. Remote PR evidence remains pending until the branch is pushed.

--- a/src/ingest_zotero_api.py
+++ b/src/ingest_zotero_api.py
@@ -272,23 +272,21 @@ class ZoteroIngestor:
             stats.committed_revision = start_revision
             return stats
 
-        # This staged-but-non-atomic bridge is replaced by ProfileStorage's E3
-        # transaction in the following implementation commit.
         active_items = result.active_items
-        if result.full:
-            local_keys = {item.key for item in self.storage.iter_items()}
-            removal_keys = local_keys - set(active_items)
-        else:
-            removal_keys = result.trashed_keys | result.deleted_keys
+        removal_keys = result.trashed_keys | result.deleted_keys
+        apply_result = self.storage.apply_zotero_sync(
+            ((staged.item, staged.content_hash) for staged in active_items.values()),
+            removal_keys,
+            full=result.full,
+            revision=result.target_revision,
+        )
 
-        for staged in active_items.values():
-            self.storage.upsert_item(staged.item, content_hash=staged.content_hash)
-        self.storage.remove_items(removal_keys)
-        self.storage.set_last_modified_version(result.target_revision)
-
-        stats.removed = len(removal_keys)
+        stats.removed = apply_result.removed if result.full else len(removal_keys)
         stats.last_modified_version = result.target_revision
         stats.committed_revision = result.target_revision
+        stats.applied_inserted = apply_result.inserted
+        stats.applied_changed = apply_result.changed
+        stats.applied_removed = apply_result.removed
         return stats
 
     def _read_start_revision(self, *, full: bool) -> Optional[int]:

--- a/src/ingest_zotero_api.py
+++ b/src/ingest_zotero_api.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import json
 import logging
 import time
-from dataclasses import dataclass
-from typing import Iterable, List, Optional
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Optional, Set
 
 import requests
 
@@ -16,14 +17,67 @@ from .utils import hash_content
 logger = logging.getLogger(__name__)
 
 API_BASE = "https://api.zotero.org"
+REVISION_RESTART_ATTEMPTS = 3
+REVISION_RESTART_BACKOFF_SECONDS = 0.25
+
+
+class ZoteroSyncError(RuntimeError):
+    """A sync attempt could not establish and commit a complete library revision."""
+
+
+class ZoteroProtocolError(ZoteroSyncError):
+    """A Zotero response could not be safely interpreted."""
+
+
+class ZoteroRevisionChanged(ZoteroSyncError):
+    """The remote library revision changed while a snapshot was being acquired."""
 
 
 @dataclass
 class IngestStats:
+    # Legacy counters. ``updated`` intentionally remains a processed-record count.
     fetched: int = 0
     updated: int = 0
     removed: int = 0
     last_modified_version: Optional[int] = None
+
+    # E3 revision state and actual SQLite mutation counters.
+    start_revision: Optional[int] = None
+    target_revision: Optional[int] = None
+    observed_revision: Optional[int] = None
+    committed_revision: Optional[int] = None
+    applied_inserted: int = 0
+    applied_changed: int = 0
+    applied_removed: int = 0
+
+
+@dataclass(frozen=True)
+class StagedRemoteItem:
+    item: ZoteroItem
+    content_hash: str
+    trashed: bool
+    raw_signature: str
+
+
+@dataclass
+class AcquisitionResult:
+    start_revision: Optional[int]
+    target_revision: int
+    observed_revision: int
+    full: bool
+    no_op: bool = False
+    items: Dict[str, StagedRemoteItem] = field(default_factory=dict)
+    deleted_keys: Set[str] = field(default_factory=set)
+    fetched: int = 0
+    updated: int = 0
+
+    @property
+    def active_items(self) -> Dict[str, StagedRemoteItem]:
+        return {key: staged for key, staged in self.items.items() if not staged.trashed}
+
+    @property
+    def trashed_keys(self) -> Set[str]:
+        return {key for key, staged in self.items.items() if staged.trashed}
 
 
 class ZoteroClient:
@@ -47,13 +101,20 @@ class ZoteroClient:
             "limit": self.settings.zotero.api.page_size,
             "sort": "dateAdded",
             "direction": "asc",
+            # Transport includes trash so move/restore transitions are observable.
+            "includeTrashed": 1,
         }
         headers = {}
         if since_version is not None:
+            params["since"] = since_version
             headers["If-Modified-Since-Version"] = str(since_version)
 
         next_url = self.base_items_url
+        visited_urls: Set[str] = set()
         while next_url:
+            if next_url in visited_urls:
+                raise ZoteroProtocolError(f"Zotero pagination cycle at {next_url}")
+            visited_urls.add(next_url)
             logger.debug("Fetching Zotero page: %s", next_url)
             resp = request_with_retry(
                 self.session,
@@ -72,13 +133,12 @@ class ZoteroClient:
             next_url = _parse_next_link(resp.headers.get("Link"))
             headers = {}
             params = {}
-            time.sleep(self.polite_delay)
+            if next_url:
+                time.sleep(self.polite_delay)
 
-    def fetch_deleted(self, since_version: Optional[int]) -> List[str]:
-        if since_version is None:
-            return []
+    def fetch_deleted(self, since_version: int) -> requests.Response:
         url = f"{self.base_user_url}/deleted"
-        resp = request_with_retry(
+        return request_with_retry(
             self.session,
             "GET",
             url,
@@ -87,10 +147,6 @@ class ZoteroClient:
             logger=logger,
             context=f"Zotero deleted-items request since version {since_version}",
         )
-        payload = resp.json() or {}
-        deleted_items = payload.get("items", [])
-        logger.info("Fetched %d deleted item tombstones", len(deleted_items))
-        return deleted_items
 
 
 def _parse_next_link(link_header: Optional[str]) -> Optional[str]:
@@ -105,6 +161,79 @@ def _parse_next_link(link_header: Optional[str]) -> Optional[str]:
     return None
 
 
+def _response_revision(response: requests.Response, *, context: str) -> int:
+    value = response.headers.get("Last-Modified-Version")
+    if value is None:
+        raise ZoteroProtocolError(f"{context} omitted Last-Modified-Version")
+    try:
+        revision = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ZoteroProtocolError(f"{context} returned invalid Last-Modified-Version") from exc
+    if revision < 0:
+        raise ZoteroProtocolError(f"{context} returned a negative Last-Modified-Version")
+    return revision
+
+
+def _response_json(response: requests.Response, *, context: str):
+    try:
+        return response.json()
+    except (TypeError, ValueError) as exc:
+        raise ZoteroProtocolError(f"{context} returned invalid JSON") from exc
+
+
+def _stage_remote_item(raw_item: object) -> StagedRemoteItem:
+    if not isinstance(raw_item, dict):
+        raise ZoteroProtocolError("Zotero item entry must be an object")
+    data = raw_item.get("data")
+    if not isinstance(data, dict):
+        raise ZoteroProtocolError("Zotero item data must be an object")
+
+    top_key = raw_item.get("key")
+    data_key = data.get("key")
+    if top_key is not None and data_key is not None and top_key != data_key:
+        raise ZoteroProtocolError("Zotero item top-level and data keys differ")
+    key = data_key if data_key is not None else top_key
+    if not isinstance(key, str) or not key.strip():
+        raise ZoteroProtocolError("Zotero item key must be a non-empty string")
+
+    top_version = raw_item.get("version")
+    data_version = data.get("version")
+    if top_version is not None and data_version is not None and top_version != data_version:
+        raise ZoteroProtocolError(f"Zotero item {key} has conflicting versions")
+    version = data_version if data_version is not None else top_version
+    if isinstance(version, bool) or not isinstance(version, int) or version < 0:
+        raise ZoteroProtocolError(f"Zotero item {key} has an invalid version")
+
+    if "deleted" in data:
+        deleted = data["deleted"]
+        if deleted is True:
+            trashed = True
+        elif isinstance(deleted, int) and not isinstance(deleted, bool) and deleted == 1:
+            trashed = True
+        else:
+            raise ZoteroProtocolError(f"Zotero item {key} has an invalid trash marker")
+    else:
+        trashed = False
+
+    try:
+        signature = json.dumps(raw_item, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        zot_item = ZoteroItem.from_zotero_api(raw_item)
+    except Exception as exc:
+        raise ZoteroProtocolError(f"Zotero item {key} could not be projected") from exc
+    content_hash = hash_content(
+        zot_item.title,
+        zot_item.abstract or "",
+        ",".join(zot_item.creators),
+        ",".join(zot_item.tags),
+    )
+    return StagedRemoteItem(
+        item=zot_item,
+        content_hash=content_hash,
+        trashed=trashed,
+        raw_signature=signature,
+    )
+
+
 class ZoteroIngestor:
     def __init__(self, storage: ProfileStorage, settings: Settings):
         self.storage = storage
@@ -112,46 +241,192 @@ class ZoteroIngestor:
         self.client = ZoteroClient(settings)
 
     def run(self, *, full: bool = False) -> IngestStats:
-        stats = IngestStats()
         self.storage.initialize()
-        since_version = None if full else self.storage.last_modified_version()
-        logger.info("Starting Zotero ingest (full=%s, since_version=%s)", full, since_version)
-        max_version = since_version or 0
+        start_revision = self._read_start_revision(full=full)
+        snapshot_mode = full or start_revision is None
+        logger.info(
+            "Starting Zotero ingest (full=%s, start_revision=%s)",
+            snapshot_mode,
+            start_revision,
+        )
 
         try:
-            for response in self.client.iter_items(since_version=since_version):
-                items = response.json()
-                response_version = int(response.headers.get("Last-Modified-Version", 0))
-                max_version = max(max_version, response_version)
-                for raw_item in items:
-                    zot_item = ZoteroItem.from_zotero_api(raw_item)
-                    content_hash = hash_content(
-                        zot_item.title,
-                        zot_item.abstract or "",
-                        ",".join(zot_item.creators),
-                        ",".join(zot_item.tags),
-                    )
-                    self.storage.upsert_item(zot_item, content_hash=content_hash)
-                    stats.fetched += 1
-                    stats.updated += 1
+            result = self._acquire_with_revision_restarts(
+                start_revision=start_revision,
+                full=snapshot_mode,
+            )
+        except ZoteroSyncError:
+            raise
         except requests.RequestException as exc:
-            logger.warning("Zotero ingest aborted after partial progress: %s", exc)
+            raise ZoteroSyncError("Zotero sync failed before a complete revision was acquired") from exc
 
-        try:
-            deleted_keys = self.client.fetch_deleted(since_version=max_version if not full else None)
-        except requests.RequestException as exc:
-            logger.warning("Skipping deleted-item sync because Zotero API was unavailable: %s", exc)
-            deleted_keys = []
-        self.storage.remove_items(deleted_keys)
-        stats.removed = len(deleted_keys)
+        stats = IngestStats(
+            fetched=result.fetched,
+            updated=result.updated,
+            start_revision=start_revision,
+            target_revision=result.target_revision,
+            observed_revision=result.observed_revision,
+        )
+        if result.no_op:
+            stats.last_modified_version = start_revision
+            stats.committed_revision = start_revision
+            return stats
 
-        if stats.fetched or full:
-            stats.last_modified_version = max_version
-            if max_version:
-                self.storage.set_last_modified_version(max_version)
-                logger.info("Updated last modified version to %s", max_version)
+        # This staged-but-non-atomic bridge is replaced by ProfileStorage's E3
+        # transaction in the following implementation commit.
+        active_items = result.active_items
+        if result.full:
+            local_keys = {item.key for item in self.storage.iter_items()}
+            removal_keys = local_keys - set(active_items)
+        else:
+            removal_keys = result.trashed_keys | result.deleted_keys
 
+        for staged in active_items.values():
+            self.storage.upsert_item(staged.item, content_hash=staged.content_hash)
+        self.storage.remove_items(removal_keys)
+        self.storage.set_last_modified_version(result.target_revision)
+
+        stats.removed = len(removal_keys)
+        stats.last_modified_version = result.target_revision
+        stats.committed_revision = result.target_revision
         return stats
 
+    def _read_start_revision(self, *, full: bool) -> Optional[int]:
+        try:
+            return self.storage.last_modified_version()
+        except (TypeError, ValueError) as exc:
+            if full:
+                logger.warning("Ignoring invalid stored Zotero revision for explicit full sync")
+                return None
+            raise ZoteroSyncError(
+                "Stored Zotero last_modified_version is invalid; run an explicit full sync"
+            ) from exc
 
-__all__ = ["ZoteroIngestor", "IngestStats"]
+    def _acquire_with_revision_restarts(
+        self,
+        *,
+        start_revision: Optional[int],
+        full: bool,
+    ) -> AcquisitionResult:
+        for attempt in range(1, REVISION_RESTART_ATTEMPTS + 1):
+            try:
+                return self._acquire_once(start_revision=start_revision, full=full)
+            except ZoteroRevisionChanged:
+                if attempt == REVISION_RESTART_ATTEMPTS:
+                    raise
+                delay = REVISION_RESTART_BACKOFF_SECONDS * attempt
+                logger.warning(
+                    "Zotero library changed during sync attempt %d/%d; restarting in %.2fs",
+                    attempt,
+                    REVISION_RESTART_ATTEMPTS,
+                    delay,
+                )
+                time.sleep(delay)
+        raise AssertionError("unreachable")
+
+    def _acquire_once(
+        self,
+        *,
+        start_revision: Optional[int],
+        full: bool,
+    ) -> AcquisitionResult:
+        request_revision = None if full else start_revision
+        target_revision: Optional[int] = None
+        observed_revision: Optional[int] = None
+        staged: Dict[str, StagedRemoteItem] = {}
+        fetched = 0
+        updated = 0
+
+        for page_number, response in enumerate(
+            self.client.iter_items(since_version=request_revision), start=1
+        ):
+            revision = _response_revision(response, context=f"Zotero items page {page_number}")
+            if target_revision is None:
+                target_revision = revision
+                if start_revision is not None and revision < start_revision:
+                    raise ZoteroProtocolError(
+                        "Zotero target revision is older than the committed revision"
+                    )
+            elif revision != target_revision:
+                raise ZoteroRevisionChanged(
+                    f"Zotero items revision changed from {target_revision} to {revision}"
+                )
+            observed_revision = revision
+
+            payload = _response_json(response, context=f"Zotero items page {page_number}")
+            if not isinstance(payload, list):
+                raise ZoteroProtocolError("Zotero items response must be a list")
+            for raw_item in payload:
+                remote = _stage_remote_item(raw_item)
+                fetched += 1
+                if not remote.trashed:
+                    updated += 1
+                existing = staged.get(remote.item.key)
+                if existing is None or remote.item.version > existing.item.version:
+                    staged[remote.item.key] = remote
+                elif remote.item.version == existing.item.version:
+                    if remote.raw_signature != existing.raw_signature:
+                        raise ZoteroProtocolError(
+                            f"Zotero item {remote.item.key} has conflicting payloads at one version"
+                        )
+                # A lower-version replay is ignored but remains part of legacy counts.
+
+        if target_revision is None:
+            if full:
+                raise ZoteroProtocolError("Full Zotero sync returned no versioned response")
+            assert start_revision is not None
+            return AcquisitionResult(
+                start_revision=start_revision,
+                target_revision=start_revision,
+                observed_revision=start_revision,
+                full=False,
+                no_op=True,
+            )
+
+        deleted_keys: Set[str] = set()
+        if not full:
+            assert start_revision is not None
+            deleted_response = self.client.fetch_deleted(start_revision)
+            deleted_revision = _response_revision(
+                deleted_response, context="Zotero deleted-items response"
+            )
+            if deleted_revision != target_revision:
+                raise ZoteroRevisionChanged(
+                    f"Zotero deleted-items revision changed from {target_revision} "
+                    f"to {deleted_revision}"
+                )
+            observed_revision = deleted_revision
+            deleted_payload = _response_json(
+                deleted_response, context="Zotero deleted-items response"
+            )
+            if not isinstance(deleted_payload, dict):
+                raise ZoteroProtocolError("Zotero deleted-items response must be an object")
+            raw_deleted = deleted_payload.get("items", [])
+            if not isinstance(raw_deleted, list):
+                raise ZoteroProtocolError("Zotero deleted item keys must be a list")
+            for key in raw_deleted:
+                if not isinstance(key, str) or not key.strip():
+                    raise ZoteroProtocolError("Zotero deleted item key must be a non-empty string")
+                deleted_keys.add(key)
+
+        assert observed_revision is not None
+        return AcquisitionResult(
+            start_revision=start_revision,
+            target_revision=target_revision,
+            observed_revision=observed_revision,
+            full=full,
+            items=staged,
+            deleted_keys=deleted_keys,
+            fetched=fetched,
+            updated=updated,
+        )
+
+
+__all__ = [
+    "ZoteroIngestor",
+    "ZoteroClient",
+    "IngestStats",
+    "ZoteroSyncError",
+    "ZoteroProtocolError",
+    "ZoteroRevisionChanged",
+]

--- a/src/storage.py
+++ b/src/storage.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Optional, Tuple
+from typing import Iterable, List, Optional, Sequence, Tuple
 
 from .models import ZoteroItem
 
@@ -33,6 +34,15 @@ CREATE TABLE IF NOT EXISTS metadata (
 
 CREATE INDEX IF NOT EXISTS idx_items_version ON items(version);
 """
+
+SQLITE_DELETE_BATCH_SIZE = 500
+
+
+@dataclass(frozen=True)
+class SyncApplyResult:
+    inserted: int = 0
+    changed: int = 0
+    removed: int = 0
 
 
 class ProfileStorage:
@@ -79,41 +89,7 @@ class ProfileStorage:
 
     # item helpers
     def upsert_item(self, item: ZoteroItem, content_hash: Optional[str] = None) -> None:
-        data = (
-            item.key,
-            item.version,
-            item.title,
-            item.abstract,
-            json.dumps(item.creators),
-            json.dumps(item.tags),
-            json.dumps(item.collections),
-            item.year,
-            item.doi,
-            item.url,
-            json.dumps(item.raw),
-            content_hash,
-        )
-        self.connect().execute(
-            """
-            INSERT INTO items(
-                key, version, title, abstract, creators, tags, collections, year, doi, url, raw_json, content_hash
-            ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(key) DO UPDATE SET
-                version=excluded.version,
-                title=excluded.title,
-                abstract=excluded.abstract,
-                creators=excluded.creators,
-                tags=excluded.tags,
-                collections=excluded.collections,
-                year=excluded.year,
-                doi=excluded.doi,
-                url=excluded.url,
-                raw_json=excluded.raw_json,
-                content_hash=excluded.content_hash,
-                updated_at=CURRENT_TIMESTAMP
-            """,
-            data,
-        )
+        _execute_upsert(self.connect(), _item_data(item, content_hash))
         self.connect().commit()
 
     def remove_items(self, keys: Iterable[str]) -> None:
@@ -123,6 +99,81 @@ class ProfileStorage:
         placeholders = ",".join("?" for _ in keys)
         self.connect().execute(f"DELETE FROM items WHERE key IN ({placeholders})", keys)
         self.connect().commit()
+
+    def apply_zotero_sync(
+        self,
+        items: Iterable[Tuple[ZoteroItem, Optional[str]]],
+        removal_keys: Iterable[str],
+        *,
+        full: bool,
+        revision: int,
+    ) -> SyncApplyResult:
+        """Apply one complete Zotero revision and its watermark atomically.
+
+        All network acquisition and validation must finish before this method is
+        called. Full mode reconciles the local key set to the supplied active
+        items; incremental mode removes only the supplied trash/tombstone keys.
+        """
+
+        item_data = [_item_data(item, content_hash) for item, content_hash in items]
+        item_keys = [data[0] for data in item_data]
+        if len(item_keys) != len(set(item_keys)):
+            raise ValueError("Zotero sync batch contains duplicate active item keys")
+        requested_removals = set(removal_keys)
+
+        conn = self.connect()
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            existing_rows = {
+                row["key"]: row
+                for row in conn.execute(
+                    """
+                    SELECT key, version, title, abstract, creators, tags, collections,
+                           year, doi, url, raw_json, content_hash
+                    FROM items
+                    """
+                )
+            }
+            if full:
+                keys_to_remove = set(existing_rows) - set(item_keys)
+            else:
+                keys_to_remove = requested_removals
+
+            # A tombstone or trash transition describes final absence and wins
+            # over an item record for the same stable library revision.
+            effective_item_data = [data for data in item_data if data[0] not in keys_to_remove]
+
+            inserted = 0
+            changed = 0
+            for data in effective_item_data:
+                existing = existing_rows.get(data[0])
+                if existing is None:
+                    inserted += 1
+                    _execute_upsert(conn, data)
+                    continue
+                if _row_item_data(existing) != data:
+                    if data[1] < existing["version"]:
+                        raise ValueError(
+                            f"Zotero item {data[0]} would regress from version "
+                            f"{existing['version']} to {data[1]}"
+                        )
+                    changed += 1
+                    _execute_upsert(conn, data)
+
+            actually_present = set(existing_rows)
+            actually_present.update(data[0] for data in effective_item_data)
+            removed = len(actually_present & keys_to_remove)
+            _delete_keys(conn, keys_to_remove)
+            conn.execute(
+                "REPLACE INTO metadata(key, value) VALUES(?, ?)",
+                ("last_modified_version", str(revision)),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+
+        return SyncApplyResult(inserted=inserted, changed=changed, removed=removed)
 
     def set_embedding(self, key: str, vector: bytes) -> None:
         self.connect().execute(
@@ -166,4 +217,70 @@ def _row_to_item(row: sqlite3.Row) -> ZoteroItem:
     )
 
 
-__all__ = ["ProfileStorage"]
+def _item_data(item: ZoteroItem, content_hash: Optional[str]) -> Tuple[object, ...]:
+    return (
+        item.key,
+        item.version,
+        item.title,
+        item.abstract,
+        json.dumps(item.creators),
+        json.dumps(item.tags),
+        json.dumps(item.collections),
+        item.year,
+        item.doi,
+        item.url,
+        json.dumps(item.raw),
+        content_hash,
+    )
+
+
+def _row_item_data(row: sqlite3.Row) -> Tuple[object, ...]:
+    return (
+        row["key"],
+        row["version"],
+        row["title"],
+        row["abstract"],
+        row["creators"],
+        row["tags"],
+        row["collections"],
+        row["year"],
+        row["doi"],
+        row["url"],
+        row["raw_json"],
+        row["content_hash"],
+    )
+
+
+def _execute_upsert(conn: sqlite3.Connection, data: Sequence[object]) -> None:
+    conn.execute(
+        """
+        INSERT INTO items(
+            key, version, title, abstract, creators, tags, collections, year, doi, url, raw_json, content_hash
+        ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(key) DO UPDATE SET
+            version=excluded.version,
+            title=excluded.title,
+            abstract=excluded.abstract,
+            creators=excluded.creators,
+            tags=excluded.tags,
+            collections=excluded.collections,
+            year=excluded.year,
+            doi=excluded.doi,
+            url=excluded.url,
+            raw_json=excluded.raw_json,
+            content_hash=excluded.content_hash,
+            updated_at=CURRENT_TIMESTAMP
+        """,
+        data,
+    )
+
+
+def _delete_keys(conn: sqlite3.Connection, keys: Iterable[str]) -> None:
+    ordered = sorted(set(keys))
+    for offset in range(0, len(ordered), SQLITE_DELETE_BATCH_SIZE):
+        batch = ordered[offset : offset + SQLITE_DELETE_BATCH_SIZE]
+        placeholders = ",".join("?" for _ in batch)
+        conn.execute(f"DELETE FROM items WHERE key IN ({placeholders})", batch)
+
+
+__all__ = ["ProfileStorage", "SyncApplyResult"]

--- a/tests/E3_RED_BASELINE.md
+++ b/tests/E3_RED_BASELINE.md
@@ -1,0 +1,29 @@
+# E3 regression red baseline
+
+Captured 2026-09-10 after test commit `9d893673013f4079cffdce496a9136e24eaf534b`.
+
+The production tree is identical to `v2-e2-baseline` (`git diff --exit-code v2-e2-baseline -- src` exited 0). Only the approved E3 plan and the new regression suite precede this capture.
+
+Command:
+
+```sh
+PYTHONHASHSEED=0 TZ=UTC OMP_NUM_THREADS=1 \
+  /private/tmp/zotwatch-e0/bin/python -m pytest \
+  -c tests/pytest.ini -q tests/test_zotero_sync_e3.py
+```
+
+Result: **25 failed, 0 passed, exit code 1**. The three warnings are the existing FAISS/SWIG deprecation warnings.
+
+The failures expose the intended E3 behavior changes:
+
+- item delta requests lack `since` and `includeTrashed`;
+- deleted requests use the newly observed revision instead of the last committed revision;
+- terminal page/deletion errors are swallowed and partial writes survive;
+- full sync does not reconcile stale or trashed rows;
+- remote revision drift is combined rather than restarted;
+- malformed payload/header/item boundaries are not represented as sync failures;
+- SQLite item changes and watermark are not one transaction;
+- revision and actual-apply counters do not yet exist;
+- 304 handling still proceeds to the deleted endpoint.
+
+This red capture is evidence, not an accepted CI state. The final E3 branch must make the suite green without marking cases xfail or changing unrelated E0 fixtures/goldens.

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,6 +24,7 @@ PYTHONHASHSEED=0 TZ=UTC OMP_NUM_THREADS=1 /tmp/zotwatch-e0-venv/bin/python -m py
 | --- | --- |
 | [test_config_cli.py](test_config_cli.py) | 旧三 YAML、env、参数/错误、7 日过滤、预印本比例、Top N、ignore、mock push、报告文件名、原 daily workflow 静态行为 |
 | [test_ingestion_dedupe.py](test_ingestion_dedupe.py) | Zotero 304/分页/新增/更新/删除/full/网络故障，真实 SQLite，DOI/URL/ID/模糊标题去重 |
+| [test_zotero_sync_e3.py](test_zotero_sync_e3.py) | E3 revision state machine、trash/restore、分页失败、远端漂移、坏记录、full 对账、SQLite 原子提交与 stats 兼容 |
 | [test_candidates.py](test_candidates.py) | 冻结 public v1 分页/映射，来源路由、12 小时 cache、故障回退与 Crossref 补抓 |
 | [test_profile_ranking_outputs.py](test_profile_ranking_outputs.py) | profile、真实 FAISS 保存/读取/检索、排名分项及稳定 tie、labels、recency 边界、SJR、RSS/HTML 完整 golden |
 | [test_pipeline_http.py](test_pipeline_http.py) | CLI profile → watch 的真实本地链路、HTTP 重试/错误、离线防护自检 |
@@ -41,10 +42,10 @@ PYTHONHASHSEED=0 TZ=UTC OMP_NUM_THREADS=1 /tmp/zotwatch-e0-venv/bin/python -m py
 | 编号 | 原版行为 | 观察测试 |
 | --- | --- | --- |
 | BUG-C1 / C2 | public key YAML 优先于 env；MAILTO env 不被配置读取 | test_bug_config_key_priority_and_mailto |
-| BUG-I1 | 删除请求使用本轮新水位，可能跳过旧水位后的删除 | test_bug_ingest_deletion_watermark_and_partial_progress |
-| BUG-I2 | 分页中断后仍可能推进同步水位 | 同上 partial=True |
-| BUG-I3 | full 不清理远端已不存在的旧条目 | test_bug_full_sync_retains_absent_rows |
-| BUG-I4 | 内容更新保留旧 embedding | test_bug_ingest_deletion_watermark_and_partial_progress |
+| BUG-I1 | **E3 已修复 / E3-SYNC-002**：删除查询固定使用本轮开始前已提交水位 | test_incremental_one_permanently_deleted_item；test_incremental_add_modify_delete_uses_start_revision |
+| BUG-I2 | **E3 已修复 / E3-SYNC-001/004**：分页或 deleted 失败不写 rows/watermark | test_middle_page_failure_leaves_rows_and_watermark_unchanged；test_deleted_endpoint_failure_leaves_rows_and_watermark_unchanged |
+| BUG-I3 | **E3 已修复 / E3-SYNC-003**：full 将 active remote key set 与本地 mirror 对账 | test_full_sync_excludes_trash_and_removes_stale_rows |
+| BUG-I4 | 内容更新保留旧 embedding；E3 不修改 computational state | test_bug_content_update_still_preserves_embedding |
 | BUG-W1 | watch 更新 SQLite 后不重建 profile/index | test_cli_profile_then_watch_real_pipeline；test_bug_watch_does_not_rebuild_and_keeps_ignore |
 | BUG-W2 | 预印本前缀比例会丢弃前排预印本；只按 source 判断 | test_bug_preprint_prefix_cap_and_source_classification |
 | BUG-F1 | public is_preprint 被丢弃 | test_public_paging_mapping_and_preprint_loss |
@@ -52,7 +53,7 @@ PYTHONHASHSEED=0 TZ=UTC OMP_NUM_THREADS=1 /tmp/zotwatch-e0-venv/bin/python -m py
 | BUG-F3 | 没有非空旧缓存时，来源失败可写成 fresh 空结果 | 同上 stale=False/supplement=False |
 | BUG-F4 | cache 不含配置 fingerprint，改来源后仍复用 12h 内旧结果 | test_cache_boundary_and_config_not_part_of_key |
 
-另记录：unchanged upsert 仍计入 updated；DOI URL prefix 不归一化；公共 title 不解码 HTML entity；Crossref 用 created 作为 published；权重总和 .95 未自动归一化。这些观察的修改也要在独立行为修复中解释。
+另记录：E3 为兼容保留 unchanged/replayed record 计入 `updated`，实际行变化由 `applied_changed` 表达；DOI URL prefix 不归一化；公共 title 不解码 HTML entity；Crossref 用 created 作为 published；权重总和 .95 未自动归一化。这些观察的修改也要在独立行为修复中解释。
 
 ## 验证证据与限制
 

--- a/tests/test_ingestion_dedupe.py
+++ b/tests/test_ingestion_dedupe.py
@@ -1,6 +1,3 @@
-from copy import deepcopy
-from dataclasses import asdict
-
 import pytest
 import requests
 
@@ -21,44 +18,41 @@ def test_client_paging_and_304(settings, monkeypatch):
     client = ingest.ZoteroClient(settings)
     assert len(list(client.iter_items(10))) == 2
     assert calls[0][2]["headers"] == {"If-Modified-Since-Version": "10"}
-    assert calls[0][2]["params"] == {"limit": 100, "sort": "dateAdded", "direction": "asc"}
+    assert calls[0][2]["params"] == {
+        "limit": 100,
+        "sort": "dateAdded",
+        "direction": "asc",
+        "includeTrashed": 1,
+        "since": 10,
+    }
     assert calls[1][2]["params"] is None
     assert calls[1][2]["headers"] == {}
     monkeypatch.setattr(ingest, "request_with_retry", lambda *a, **kw: Response(status=304))
     assert list(client.iter_items(10)) == []
 
 
-@pytest.mark.parametrize("partial", [False, True])
-def test_bug_ingest_deletion_watermark_and_partial_progress(library, settings, monkeypatch, partial):
-    # BUG-I1/I2: deletion query uses new watermark, even after page failure.
+def test_bug_content_update_still_preserves_embedding(library, settings, monkeypatch):
+    # BUG-I4 remains outside E3: source changes do not invalidate embeddings.
     library.set_last_modified_version(10)
     library.set_embedding("LIB1", b"old-embedding")
     rows = read_json(FIXTURES / "zotero.json")
+    rows[0]["version"] = 20
     rows[0]["data"].update(version=20, title="Updated genome")
-    new = deepcopy(rows[1])
-    new["data"].update(key="LIB3", version=20, title="New synthetic work")
-    calls = []
-    def request(session, method, url, **kwargs):
-        calls.append((url, kwargs))
-        if url.endswith("/deleted"):
-            return Response({"items": ["LIB2"]})
-        if "start=" in url:
-            if partial:
-                raise requests.ConnectionError("synthetic page failure")
-            return Response([new], headers={"Last-Modified-Version": "20"})
-        return Response([rows[0]], headers={"Last-Modified-Version": "20", "Link": '<https://api.zotero.org/users/123456/items?start=100>; rel="next"'})
+    replies = iter([
+        Response([rows[0]], headers={"Last-Modified-Version": "20"}),
+        Response({"items": []}, headers={"Last-Modified-Version": "20"}),
+    ])
+    def request(*args, **kwargs):
+        return next(replies)
     monkeypatch.setattr(ingest, "request_with_retry", request)
     stats = ingest.ZoteroIngestor(library, settings).run()
-    assert asdict(stats) == dict(fetched=1 if partial else 2, updated=1 if partial else 2, removed=1, last_modified_version=20)
-    assert calls[-1][1]["params"] == {"since": 20}
+    assert (stats.fetched, stats.updated, stats.removed) == (1, 1, 0)
     assert library.last_modified_version() == 20
-    assert [item.key for item in library.iter_items()] == (["LIB1"] if partial else ["LIB1", "LIB3"])
     assert next(library.iter_items()).title == "Updated genome"
-    # BUG-I4: changing content does not invalidate its stored embedding.
     assert library.fetch_all_embeddings() == [("LIB1", b"old-embedding")]
 
 
-def test_bug_full_sync_retains_absent_rows(library, settings, monkeypatch):
+def test_e3_full_sync_removes_absent_rows(library, settings, monkeypatch):
     library.set_last_modified_version(10)
     rows = read_json(FIXTURES / "zotero.json")
     calls = []
@@ -69,11 +63,11 @@ def test_bug_full_sync_retains_absent_rows(library, settings, monkeypatch):
     stats = ingest.ZoteroIngestor(library, settings).run(full=True)
     assert len(calls) == 1  # Full does not request tombstones.
     assert calls[0]["headers"] == {}
-    assert stats.removed == 0
-    assert [item.key for item in library.iter_items()] == ["LIB1", "LIB2"]
+    assert stats.removed == stats.applied_removed == 1
+    assert [item.key for item in library.iter_items()] == ["LIB1"]
 
 
-def test_304_still_fetches_deletions(library, settings, monkeypatch):
+def test_304_is_successful_noop_without_deleted_request(library, settings, monkeypatch):
     library.set_last_modified_version(10)
     calls = []
     def request(session, method, url, **kw):
@@ -81,20 +75,22 @@ def test_304_still_fetches_deletions(library, settings, monkeypatch):
         return Response({"items": ["LIB2"]}) if url.endswith("/deleted") else Response(status=304)
     monkeypatch.setattr(ingest, "request_with_retry", request)
     stats = ingest.ZoteroIngestor(library, settings).run()
-    assert asdict(stats) == dict(fetched=0, updated=0, removed=1, last_modified_version=None)
-    assert calls[-1][1]["params"] == {"since": 10}
+    assert (stats.fetched, stats.updated, stats.removed) == (0, 0, 0)
+    assert stats.last_modified_version == stats.committed_revision == 10
+    assert len(calls) == 1
     assert library.last_modified_version() == 10
 
 
 def test_total_network_failure_keeps_existing_state(library, settings, monkeypatch):
     library.set_last_modified_version(10)
+    before = [item.model_dump() for item in library.iter_items()]
     def fail(*a, **kw):
         raise requests.Timeout("synthetic timeout")
     monkeypatch.setattr(ingest, "request_with_retry", fail)
-    stats = ingest.ZoteroIngestor(library, settings).run()
-    assert asdict(stats) == dict(fetched=0, updated=0, removed=0, last_modified_version=None)
+    with pytest.raises(ingest.ZoteroSyncError):
+        ingest.ZoteroIngestor(library, settings).run()
     assert library.last_modified_version() == 10
-    assert len(list(library.iter_items())) == 2
+    assert [item.model_dump() for item in library.iter_items()] == before
 
 
 def test_item_mapping_and_unchanged_upsert_count(library, settings, monkeypatch):

--- a/tests/test_pipeline_http.py
+++ b/tests/test_pipeline_http.py
@@ -17,7 +17,7 @@ def test_cli_profile_then_watch_real_pipeline(workspace, settings, candidates, m
     rows = read_json(FIXTURES / "zotero.json")
     replies = iter([Response(rows, headers={"Last-Modified-Version": "10"}),
                     Response([{"data": {"key": "NEW", "version": 20, "title": "New library science"}}], headers={"Last-Modified-Version": "20"}),
-                    Response({"items": []})])
+                    Response({"items": []}, headers={"Last-Modified-Version": "20"})])
     monkeypatch.setattr(ingest_zotero_api, "request_with_retry", lambda *a, **kw: next(replies))
     monkeypatch.setattr(build_profile, "TextVectorizer", FixedVectors)
     monkeypatch.setattr(score_rank, "TextVectorizer", FixedVectors)

--- a/tests/test_zotero_sync_e3.py
+++ b/tests/test_zotero_sync_e3.py
@@ -14,6 +14,7 @@ import requests
 
 from src import ingest_zotero_api as ingest
 from src.models import ZoteroItem
+from src.utils import hash_content
 from .helpers import FIXTURES, Response, read_json
 
 
@@ -293,6 +294,22 @@ def test_middle_page_failure_leaves_rows_and_watermark_unchanged(library, settin
     assert mirror_state(library) == before
 
 
+def test_full_middle_page_failure_does_not_replace_existing_mirror(library, settings, monkeypatch):
+    library.set_last_modified_version(10)
+    before = mirror_state(library)
+    next_url = "https://api.zotero.org/users/123456/items?start=100"
+    script = ScriptedRequests(
+        response([remote_item("FIRST", 20, "First page")], 20, link=next_url),
+        requests.ConnectionError("synthetic full middle-page failure"),
+    )
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    with pytest.raises(ingest.ZoteroSyncError):
+        ingest.ZoteroIngestor(library, settings).run(full=True)
+
+    assert mirror_state(library) == before
+
+
 def test_deleted_endpoint_failure_leaves_rows_and_watermark_unchanged(library, settings, monkeypatch):
     library.set_last_modified_version(10)
     before = mirror_state(library)
@@ -368,6 +385,29 @@ def test_remote_revision_change_discards_attempt_and_restarts(library, settings,
     assert all(call[2]["params"]["since"] == 10 for call in first_item_calls)
     assert keys(library) == ["LIB1", "LIB3", "LIB4"]
     assert_success_revisions(stats, 10, 22)
+
+
+def test_repeated_remote_revision_drift_exhausts_bound_and_keeps_state(library, settings, monkeypatch):
+    library.set_last_modified_version(10)
+    before = mirror_state(library)
+    next_url = "https://api.zotero.org/users/123456/items?start=100"
+    script = ScriptedRequests(
+        response([remote_item("A", 20, "A")], 20, link=next_url),
+        response([remote_item("B", 21, "B")], 21),
+        response([remote_item("A", 22, "A")], 22, link=next_url),
+        response([remote_item("B", 23, "B")], 23),
+        response([remote_item("A", 24, "A")], 24, link=next_url),
+        response([remote_item("B", 25, "B")], 25),
+    )
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    with pytest.raises(ingest.ZoteroRevisionChanged):
+        ingest.ZoteroIngestor(library, settings).run()
+
+    base_calls = [call for call in script.calls if call[1].endswith("/items")]
+    assert len(base_calls) == ingest.REVISION_RESTART_ATTEMPTS == 3
+    assert all(call[2]["params"]["since"] == 10 for call in base_calls)
+    assert mirror_state(library) == before
 
 
 @pytest.mark.parametrize(
@@ -478,4 +518,25 @@ def test_unknown_tombstone_preserves_legacy_removed_but_applied_count_is_zero(st
 
     assert stats.removed == 1
     assert stats.applied_removed == 0
+    assert_success_revisions(stats, 10, 20)
+
+
+def test_unchanged_replay_counts_legacy_updated_without_actual_change(storage, settings, monkeypatch):
+    unchanged = remote_item("UNCHANGED", 10, "Same")
+    item = ZoteroItem.from_zotero_api(unchanged)
+    content_hash = hash_content(
+        item.title,
+        item.abstract or "",
+        ",".join(item.creators),
+        ",".join(item.tags),
+    )
+    storage.upsert_item(item, content_hash=content_hash)
+    storage.set_last_modified_version(10)
+    script = ScriptedRequests(response([unchanged], 20), response({"items": []}, 20))
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    stats = ingest.ZoteroIngestor(storage, settings).run()
+
+    assert stats.updated == 1
+    assert (stats.applied_inserted, stats.applied_changed, stats.applied_removed) == (0, 0, 0)
     assert_success_revisions(stats, 10, 20)

--- a/tests/test_zotero_sync_e3.py
+++ b/tests/test_zotero_sync_e3.py
@@ -1,0 +1,481 @@
+"""E3 Zotero mirror correctness regressions.
+
+These tests use synthetic Zotero responses and a real temporary SQLite database.
+The first commit intentionally fails against v2-e2-baseline production code.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from copy import deepcopy
+
+import pytest
+import requests
+
+from src import ingest_zotero_api as ingest
+from src.models import ZoteroItem
+from .helpers import FIXTURES, Response, read_json
+
+
+def remote_item(key: str, version: int, title: str, *, deleted: bool = False) -> dict:
+    data = {
+        "key": key,
+        "version": version,
+        "itemType": "journalArticle",
+        "title": title,
+        "abstractNote": "Synthetic abstract",
+        "creators": [],
+        "tags": [],
+        "collections": [],
+        "date": "2026",
+        "DOI": f"10.0000/{key.lower()}",
+        "url": f"https://example.invalid/{key.lower()}",
+    }
+    if deleted:
+        # Zotero Web API v3 emits integer 1 for an item in trash.
+        data["deleted"] = 1
+    return {"key": key, "version": version, "data": data}
+
+
+def response(payload, version: int, *, link: str | None = None) -> Response:
+    headers = {"Last-Modified-Version": str(version)}
+    if link:
+        headers["Link"] = f'<{link}>; rel="next"'
+    return Response(payload, headers=headers)
+
+
+class ScriptedRequests:
+    def __init__(self, *replies):
+        self.replies = list(replies)
+        self.calls = []
+
+    def __call__(self, session, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        if not self.replies:
+            raise AssertionError(f"unexpected Zotero request: {method} {url}")
+        reply = self.replies.pop(0)
+        if isinstance(reply, BaseException):
+            raise reply
+        return reply
+
+
+def mirror_state(storage):
+    rows = storage.connect().execute(
+        """
+        SELECT key, version, title, abstract, creators, tags, collections,
+               year, doi, url, raw_json, content_hash, embedding
+        FROM items ORDER BY key
+        """
+    ).fetchall()
+    return [tuple(row) for row in rows], storage.get_metadata("last_modified_version")
+
+
+def keys(storage) -> list[str]:
+    return sorted(item.key for item in storage.iter_items())
+
+
+def assert_success_revisions(stats, start: int | None, target: int) -> None:
+    assert stats.start_revision == start
+    assert stats.target_revision == target
+    assert stats.observed_revision == target
+    assert stats.committed_revision == target
+    assert stats.last_modified_version == target
+
+
+def assert_incremental_query(call, start: int) -> None:
+    _, url, kwargs = call
+    assert url.endswith("/items")
+    assert kwargs["params"] == {
+        "limit": 100,
+        "sort": "dateAdded",
+        "direction": "asc",
+        "since": start,
+        "includeTrashed": 1,
+    }
+    assert kwargs["headers"] == {"If-Modified-Since-Version": str(start)}
+
+
+def test_initial_sync_without_watermark_establishes_full_active_mirror(storage, settings, monkeypatch):
+    storage.upsert_item(ZoteroItem.from_zotero_api(remote_item("STALE", 3, "Stale")))
+    script = ScriptedRequests(
+        response(
+            [remote_item("ACTIVE", 20, "Active"), remote_item("TRASHED", 20, "Trashed", deleted=True)],
+            20,
+        )
+    )
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    stats = ingest.ZoteroIngestor(storage, settings).run()
+
+    assert keys(storage) == ["ACTIVE"]
+    assert storage.last_modified_version() == 20
+    assert script.calls[0][2]["params"]["includeTrashed"] == 1
+    assert "since" not in script.calls[0][2]["params"]
+    assert_success_revisions(stats, None, 20)
+
+
+def test_noop_304_keeps_committed_revision_and_skips_deleted(library, settings, monkeypatch):
+    library.set_last_modified_version(10)
+    before = mirror_state(library)
+    script = ScriptedRequests(Response(status=304))
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    stats = ingest.ZoteroIngestor(library, settings).run()
+
+    assert mirror_state(library) == before
+    assert len(script.calls) == 1
+    assert_incremental_query(script.calls[0], 10)
+    assert_success_revisions(stats, 10, 10)
+    assert (stats.fetched, stats.updated, stats.removed) == (0, 0, 0)
+    assert (stats.applied_inserted, stats.applied_changed, stats.applied_removed) == (0, 0, 0)
+
+
+def test_incremental_one_added_item(storage, settings, monkeypatch):
+    storage.set_last_modified_version(10)
+    script = ScriptedRequests(
+        response([remote_item("ADDED", 20, "Added")], 20),
+        response({"items": []}, 20),
+    )
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    stats = ingest.ZoteroIngestor(storage, settings).run()
+
+    assert keys(storage) == ["ADDED"]
+    assert (stats.fetched, stats.updated, stats.removed) == (1, 1, 0)
+    assert (stats.applied_inserted, stats.applied_changed, stats.applied_removed) == (1, 0, 0)
+    assert_success_revisions(stats, 10, 20)
+
+
+def test_incremental_one_modified_item(library, settings, monkeypatch):
+    library.set_last_modified_version(10)
+    modified = remote_item("LIB1", 20, "Modified title")
+    script = ScriptedRequests(response([modified], 20), response({"items": []}, 20))
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    stats = ingest.ZoteroIngestor(library, settings).run()
+
+    assert next(item for item in library.iter_items() if item.key == "LIB1").title == "Modified title"
+    assert (stats.fetched, stats.updated, stats.removed) == (1, 1, 0)
+    assert (stats.applied_inserted, stats.applied_changed, stats.applied_removed) == (0, 1, 0)
+    assert_success_revisions(stats, 10, 20)
+
+
+def test_incremental_one_permanently_deleted_item(library, settings, monkeypatch):
+    library.set_last_modified_version(10)
+    script = ScriptedRequests(response([], 20), response({"items": ["LIB2"]}, 20))
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    stats = ingest.ZoteroIngestor(library, settings).run()
+
+    assert script.calls[1][2]["params"] == {"since": 10}
+    assert keys(library) == ["LIB1"]
+    assert (stats.fetched, stats.updated, stats.removed) == (0, 0, 1)
+    assert (stats.applied_inserted, stats.applied_changed, stats.applied_removed) == (0, 0, 1)
+    assert_success_revisions(stats, 10, 20)
+
+
+def test_incremental_add_modify_delete_uses_start_revision(library, settings, monkeypatch):
+    library.set_last_modified_version(10)
+    original = read_json(FIXTURES / "zotero.json")[0]
+    modified = deepcopy(original)
+    modified["version"] = 20
+    modified["data"].update(version=20, title="Updated genome")
+    added = remote_item("LIB3", 20, "New work")
+    script = ScriptedRequests(
+        response([modified, added], 20),
+        response({"items": ["LIB2"]}, 20),
+    )
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    stats = ingest.ZoteroIngestor(library, settings).run()
+
+    assert_incremental_query(script.calls[0], 10)
+    assert script.calls[1][1].endswith("/deleted")
+    assert script.calls[1][2]["params"] == {"since": 10}
+    assert keys(library) == ["LIB1", "LIB3"]
+    assert next(item for item in library.iter_items() if item.key == "LIB1").title == "Updated genome"
+    assert_success_revisions(stats, 10, 20)
+    assert (stats.fetched, stats.updated, stats.removed) == (2, 2, 1)
+    assert (stats.applied_inserted, stats.applied_changed, stats.applied_removed) == (1, 1, 1)
+
+
+def test_existing_item_moved_to_trash_is_removed_and_revision_committed(library, settings, monkeypatch):
+    library.set_last_modified_version(10)
+    script = ScriptedRequests(
+        response([remote_item("LIB1", 20, "Genome atlas", deleted=True)], 20),
+        response({"items": []}, 20),
+    )
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    stats = ingest.ZoteroIngestor(library, settings).run()
+
+    assert_incremental_query(script.calls[0], 10)
+    assert keys(library) == ["LIB2"]
+    assert_success_revisions(stats, 10, 20)
+    assert (stats.fetched, stats.updated, stats.removed) == (1, 0, 1)
+    assert stats.applied_removed == 1
+
+
+def test_trashed_item_restored_reenters_local_mirror(storage, settings, monkeypatch):
+    storage.set_last_modified_version(10)
+    script = ScriptedRequests(
+        response([remote_item("RESTORED", 20, "Restored work")], 20),
+        response({"items": []}, 20),
+    )
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    stats = ingest.ZoteroIngestor(storage, settings).run()
+
+    assert keys(storage) == ["RESTORED"]
+    assert_success_revisions(stats, 10, 20)
+    assert (stats.fetched, stats.updated, stats.removed) == (1, 1, 0)
+    assert stats.applied_inserted == 1
+
+
+def test_full_sync_excludes_trash_and_removes_stale_rows(library, settings, monkeypatch):
+    library.set_last_modified_version(10)
+    script = ScriptedRequests(
+        response(
+            [
+                remote_item("LIB1", 20, "Current genome"),
+                remote_item("LIB2", 20, "Trashed ocean", deleted=True),
+                remote_item("LIB3", 20, "New active"),
+            ],
+            20,
+        )
+    )
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    stats = ingest.ZoteroIngestor(library, settings).run(full=True)
+
+    assert len(script.calls) == 1
+    assert script.calls[0][2]["params"]["includeTrashed"] == 1
+    assert keys(library) == ["LIB1", "LIB3"]
+    assert_success_revisions(stats, 10, 20)
+    assert stats.applied_removed == 1
+
+
+def test_multi_page_sync_commits_only_after_deleted_response(library, settings, monkeypatch):
+    library.set_last_modified_version(10)
+    next_url = "https://api.zotero.org/users/123456/items?start=100&since=10&includeTrashed=1"
+    script = ScriptedRequests(
+        response([remote_item("LIB3", 20, "Page one")], 20, link=next_url),
+        response([remote_item("LIB4", 20, "Page two")], 20),
+        response({"items": ["LIB2"]}, 20),
+    )
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    stats = ingest.ZoteroIngestor(library, settings).run()
+
+    assert keys(library) == ["LIB1", "LIB3", "LIB4"]
+    assert [call[1] for call in script.calls] == [
+        "https://api.zotero.org/users/123456/items",
+        next_url,
+        "https://api.zotero.org/users/123456/deleted",
+    ]
+    assert_success_revisions(stats, 10, 20)
+
+
+def test_middle_page_failure_leaves_rows_and_watermark_unchanged(library, settings, monkeypatch):
+    library.set_last_modified_version(10)
+    before = mirror_state(library)
+    next_url = "https://api.zotero.org/users/123456/items?start=100"
+    script = ScriptedRequests(
+        response([remote_item("LIB3", 20, "Partial")], 20, link=next_url),
+        requests.ConnectionError("synthetic middle-page failure"),
+        response({"items": []}, 20),  # Old implementation incorrectly continues here.
+    )
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    with pytest.raises(ingest.ZoteroSyncError):
+        ingest.ZoteroIngestor(library, settings).run()
+
+    assert mirror_state(library) == before
+
+
+def test_deleted_endpoint_failure_leaves_rows_and_watermark_unchanged(library, settings, monkeypatch):
+    library.set_last_modified_version(10)
+    before = mirror_state(library)
+    script = ScriptedRequests(
+        response([remote_item("LIB3", 20, "Staged")], 20),
+        requests.Timeout("synthetic deleted-endpoint failure"),
+    )
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    with pytest.raises(ingest.ZoteroSyncError):
+        ingest.ZoteroIngestor(library, settings).run()
+
+    assert mirror_state(library) == before
+
+
+def test_retry_after_failed_sync_replays_from_original_watermark(library, settings, monkeypatch):
+    library.set_last_modified_version(10)
+    before = mirror_state(library)
+    first = ScriptedRequests(
+        response([remote_item("LIB3", 20, "Staged")], 20),
+        requests.Timeout("synthetic deleted-endpoint failure"),
+    )
+    monkeypatch.setattr(ingest, "request_with_retry", first)
+    with pytest.raises(ingest.ZoteroSyncError):
+        ingest.ZoteroIngestor(library, settings).run()
+    assert mirror_state(library) == before
+
+    second = ScriptedRequests(
+        response([remote_item("LIB3", 20, "Staged")], 20),
+        response({"items": ["LIB2"]}, 20),
+    )
+    monkeypatch.setattr(ingest, "request_with_retry", second)
+    stats = ingest.ZoteroIngestor(library, settings).run()
+
+    assert_incremental_query(second.calls[0], 10)
+    assert keys(library) == ["LIB1", "LIB3"]
+    assert_success_revisions(stats, 10, 20)
+
+
+def test_duplicate_replayed_page_is_idempotent_and_preserves_legacy_updated(storage, settings, monkeypatch):
+    storage.set_last_modified_version(10)
+    duplicate = remote_item("DUPLICATE", 20, "One row")
+    next_url = "https://api.zotero.org/users/123456/items?start=100"
+    script = ScriptedRequests(
+        response([duplicate], 20, link=next_url),
+        response([deepcopy(duplicate)], 20),
+        response({"items": []}, 20),
+    )
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    stats = ingest.ZoteroIngestor(storage, settings).run()
+
+    assert keys(storage) == ["DUPLICATE"]
+    assert (stats.fetched, stats.updated) == (2, 2)
+    assert (stats.applied_inserted, stats.applied_changed) == (1, 0)
+
+
+def test_remote_revision_change_discards_attempt_and_restarts(library, settings, monkeypatch):
+    library.set_last_modified_version(10)
+    first_next = "https://api.zotero.org/users/123456/items?start=100"
+    script = ScriptedRequests(
+        response([remote_item("LIB3", 20, "Attempt one")], 20, link=first_next),
+        response([remote_item("LIB4", 21, "Drift")], 21),
+        response([remote_item("LIB3", 22, "Stable"), remote_item("LIB4", 22, "Stable too")], 22),
+        response({"items": ["LIB2"]}, 22),
+    )
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    stats = ingest.ZoteroIngestor(library, settings).run()
+
+    first_item_calls = [call for call in script.calls if call[1].endswith("/items")]
+    assert len(first_item_calls) == 2
+    assert all(call[2]["params"]["since"] == 10 for call in first_item_calls)
+    assert keys(library) == ["LIB1", "LIB3", "LIB4"]
+    assert_success_revisions(stats, 10, 22)
+
+
+@pytest.mark.parametrize(
+    "bad_payload",
+    [
+        {"unexpected": "object instead of item list"},
+        [remote_item("GOOD", 20, "Good"), {"data": {"version": 20, "title": "Missing key"}}],
+        [remote_item("GOOD", 20, "Good"), remote_item("BADTRASH", 20, "Bad trash")],
+    ],
+    ids=["wrong-page-shape", "missing-item-key", "invalid-trash-marker"],
+)
+def test_malformed_item_or_payload_aborts_whole_sync(storage, settings, monkeypatch, bad_payload):
+    storage.set_last_modified_version(10)
+    if isinstance(bad_payload, list) and bad_payload[-1].get("data", {}).get("key") == "BADTRASH":
+        bad_payload[-1]["data"]["deleted"] = "yes"
+    before = mirror_state(storage)
+    script = ScriptedRequests(response(bad_payload, 20), response({"items": []}, 20))
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    with pytest.raises(ingest.ZoteroSyncError):
+        ingest.ZoteroIngestor(storage, settings).run()
+
+    assert mirror_state(storage) == before
+
+
+@pytest.mark.parametrize("header", [{}, {"Last-Modified-Version": "not-an-int"}])
+def test_missing_or_invalid_revision_header_aborts_sync(storage, settings, monkeypatch, header):
+    storage.set_last_modified_version(10)
+    before = mirror_state(storage)
+    script = ScriptedRequests(Response([remote_item("GOOD", 20, "Good")], headers=header))
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    with pytest.raises(ingest.ZoteroSyncError):
+        ingest.ZoteroIngestor(storage, settings).run()
+
+    assert mirror_state(storage) == before
+
+
+def test_pagination_cycle_aborts_without_writes(storage, settings, monkeypatch):
+    storage.set_last_modified_version(10)
+    before = mirror_state(storage)
+    repeated = "https://api.zotero.org/users/123456/items?start=100"
+    script = ScriptedRequests(
+        response([remote_item("GOOD", 20, "Good")], 20, link=repeated),
+        response([remote_item("OTHER", 20, "Other")], 20, link=repeated),
+    )
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    with pytest.raises(ingest.ZoteroSyncError):
+        ingest.ZoteroIngestor(storage, settings).run()
+
+    assert mirror_state(storage) == before
+
+
+def test_valid_empty_full_snapshot_removes_rows_only_after_complete_response(library, settings, monkeypatch):
+    library.set_last_modified_version(10)
+    script = ScriptedRequests(response([], 20))
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    stats = ingest.ZoteroIngestor(library, settings).run(full=True)
+
+    assert keys(library) == []
+    assert library.last_modified_version() == 20
+    assert stats.applied_removed == 2
+
+
+def test_full_sync_network_failure_preserves_existing_database(library, settings, monkeypatch):
+    library.set_last_modified_version(10)
+    before = mirror_state(library)
+    script = ScriptedRequests(requests.Timeout("synthetic full-sync failure"))
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    with pytest.raises(ingest.ZoteroSyncError):
+        ingest.ZoteroIngestor(library, settings).run(full=True)
+
+    assert mirror_state(library) == before
+
+
+def test_sqlite_failure_rolls_back_items_deletions_and_watermark(storage, settings, monkeypatch):
+    storage.set_last_modified_version(10)
+    storage.connect().execute(
+        """
+        CREATE TRIGGER fail_e3_insert BEFORE INSERT ON items
+        WHEN NEW.key = 'FAIL'
+        BEGIN SELECT RAISE(ABORT, 'synthetic E3 apply failure'); END
+        """
+    )
+    storage.connect().commit()
+    before = mirror_state(storage)
+    script = ScriptedRequests(
+        response([remote_item("GOOD", 20, "Good"), remote_item("FAIL", 20, "Fail")], 20),
+        response({"items": []}, 20),
+    )
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    with pytest.raises(sqlite3.DatabaseError):
+        ingest.ZoteroIngestor(storage, settings).run()
+
+    assert mirror_state(storage) == before
+
+
+def test_unknown_tombstone_preserves_legacy_removed_but_applied_count_is_zero(storage, settings, monkeypatch):
+    storage.set_last_modified_version(10)
+    script = ScriptedRequests(response([], 20), response({"items": ["UNKNOWN"]}, 20))
+    monkeypatch.setattr(ingest, "request_with_retry", script)
+
+    stats = ingest.ZoteroIngestor(storage, settings).run()
+
+    assert stats.removed == 1
+    assert stats.applied_removed == 0
+    assert_success_revisions(stats, 10, 20)


### PR DESCRIPTION
A failed or concurrent Zotero sync could previously commit partial pages, skip deletions by querying from the newly observed watermark, or leave stale rows after a full sync. Moving an item to trash could also make it disappear from the default `/items` query without producing a permanent-deletion tombstone.

This PR stages the JSON delta in memory, requires one stable `Last-Modified-Version` across every item page and the deleted response, and commits item upserts, trash/tombstone removals, full-snapshot reconciliation, and `metadata.last_modified_version` in one SQLite transaction. Incremental and full transport use `includeTrashed=1`; `data.deleted: 1` removes the item from ZotWatch's active-only local mirror, and a later active response restores it. Terminal sync failures now propagate instead of allowing profile/ranking to continue from an incomplete mirror.

`IngestStats.updated` keeps its legacy processed-active-record meaning. New `applied_inserted`, `applied_changed`, and `applied_removed` fields report actual SQLite mutations, and the revision fields distinguish start, target, observed, and committed revisions. Existing API key/user ID names, CLI entry points, SQLite schema, and non-sync behavior remain compatible.

Validation:

- Tests-only commit against unchanged E2 production: 25 failed, exit 1, as expected.
- Focused sync/ingestion/pipeline: 46 passed.
- Offline characterization, two consecutive local runs: 151 passed each; installation-only cases skipped by design.
- Fresh sdist/wheel plus editable local installation gate: 167 passed, 0 skipped; both `pip check` commands passed.
- Final-head remote [E0 characterization](https://github.com/Yorks0n/ZotWatch/actions/runs/34472973612): passed.
- Final-head remote [E1 packaging and E2 config](https://github.com/Yorks0n/ZotWatch/actions/runs/34472973735): passed, including installed engines outside checkout and immutable E0 inputs.
- Original E0 goldens/fixtures unchanged; no ranking, candidate, AI, state-artifact, workflow/template, Cloudflare, or harvester changes.