### PR TITLE
E5A: execute Basic v2 through the existing runtime pipeline

### DIFF
--- a/.github/workflows/characterization.yml
+++ b/.github/workflows/characterization.yml
@@ -3,7 +3,7 @@ name: E0 characterization
 on:
   pull_request:
   push:
-    branches: [main, codex/dev, codex/v2, codex/v2-e0, codex/v2-e2, codex/v2-e4]
+    branches: [main, codex/dev, codex/v2, codex/v2-e0, codex/v2-e2, codex/v2-e4, codex/v2-e5a]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -3,7 +3,7 @@ name: E1 packaging and E2 config
 on:
   pull_request:
   push:
-    branches: [codex/v2, codex/v2-e1, codex/v2-e2, codex/v2-e4]
+    branches: [codex/v2, codex/v2-e1, codex/v2-e2, codex/v2-e4, codex/v2-e5a]
   workflow_dispatch:
 
 permissions:

--- a/E5_IMPLEMENTATION_PLAN.md
+++ b/E5_IMPLEMENTATION_PLAN.md
@@ -2,7 +2,7 @@
 
 日期：2026-09-11
 
-状态：**plan only；等待审阅，尚未修改 production code。**
+状态：**已批准；E5A implementation complete，等待远端封板；E5B 尚未开始。**
 
 起点：`v2-e4-baseline` / `5afdaa603ec5e9978ea871505c6233c33e23b7a3`。
 

--- a/E5_IMPLEMENTATION_PLAN.md
+++ b/E5_IMPLEMENTATION_PLAN.md
@@ -24,6 +24,13 @@ E5 是 P2 reusable workflow / thin workspace 前最后一个 engine 阶段。它
 
 E5 不实现 reusable workflow、workspace-template、GitHub artifact/cache transport、Cloudflare、Zotero OAuth、AI 网络 adapter、AI rerank/summary、clustering、新 ranking、durable feedback、harvester 修复或 public candidate API redesign。
 
+### 1.1 Approved implementation clarifications
+
+- **E5A output capability checkpoint**：E5A 只执行 `rss` / `html`。虽然 E2 schema 已允许 `json`，但 E5A 在 preflight 将任何 enabled `json` request 明确报告为 `OUTPUT_FORMAT_UNAVAILABLE`，使用 capability/credential exit category 3，并在 Zotero sync、model load、candidate network 或其他 recommendation side effect 前停止。E5A 不 silent-ignore JSON，也不提前实现半套 JSON contract。E5A equivalence fixture 使用只含 RSS/HTML 的 v2 config；E5B 合入后 registry/capability table 才把 JSON 标为 supported。`v2-e5a-baseline` 只是内部 checkpoint，不满足最终 P2 JSON requirement。
+- **Complete legacy score provenance**：recommendation JSON v1 分别输出 `similarity`、`recency`、`citations`、`altmetric`、`journal_quality`、`author_bonus`、`venue_bonus` 七个 component。每项包含 `raw_value`、`weighted_contribution` 和 `input_available`；正常浮点容差内 `score == sum(weighted_contribution)`。E5B 可给内部 `RankedWork` 增加 additive `altmetric_score` / provenance 字段，但不改变公式、weights、threshold 或排序。
+- **Explicit preprint transport**：E5B 给 `CandidateWork` 增加 optional `is_preprint`。`public-api-v1` 原样保留 payload 的明确 boolean；明确的 arXiv/bioRxiv/medRxiv adapter 设置 `true`；无法确定时保持 `null`。JSON projector 不按标题、类型、URL 或“不是已知 preprint source”猜 false。`public_id` 继续从当前 whitelist metadata 显式投影，不复制 `extra`。
+- **P2 artifact authority**：immutable successful output generation、finalized artifact list 和 `latest-success` pointer 是 machine authority。stable report paths 仅为兼容/用户 alias。`RunResult` 与 private run manifest 给 P2 的 references 必须指向 immutable generation 内的相对路径，并包含 hash、size、media type；P2 后续按 finalized whitelist 上传/发布，不扫描 reports、不看 mtime、不依赖 aliases 的瞬时一致性。
+
 ## 2. 当前 runtime / output flow
 
 当前 public console entry `zotwatch.cli.main()` 有两条行为：
@@ -145,7 +152,7 @@ E5A accepts only the capabilities already constrained by config schema v2:
 | `ranking.policy=legacy-v1` | Exact frozen legacy weights, thresholds, decay rules and whitelist defaults used by the ordinary legacy projection. No scoring formula changes. |
 | `ranking.top_n` | Run top limit when no legacy compatibility wrapper is involved. |
 | `ranking.max_preprint_ratio=0.3` | Existing deterministic `_limit_preprints` policy. |
-| `outputs.formats` | Requested local render set for v2 `watch`; `profile` produces no recommendation outputs. |
+| `outputs.formats` | Requested local render set for v2 `watch`; E5A supports RSS/HTML and rejects JSON before side effects，E5B enables JSON；`profile` produces no recommendation outputs. |
 | `outputs.publish` | Recorded publish intent only. E5 performs no Pages/GitHub publication; P2 consumes this flag. |
 | disabled AI features | No route, credential or network requirement. |
 
@@ -162,7 +169,7 @@ zotwatch profile --workspace <workspace> [--full|--weekly]
 zotwatch watch --workspace <workspace> [--strict]
 ```
 
-For v2 `watch`, `top_n`, preprint ratio and output formats come from `zotwatch.yaml`. Existing legacy-only `--rss`, `--report`, `--top`, `--push` and custom journal-metrics switches are rejected as `CONFIG_OPTION_UNSUPPORTED` before Zotero sync when used with v2; this avoids an undocumented effective-config merge. P2 will invoke the canonical no-overlay form.
+For v2 `watch`, `top_n`, preprint ratio and output formats come from `zotwatch.yaml`. During E5A, `json` maps to `OUTPUT_FORMAT_UNAVAILABLE` before side effects; RSS/HTML continue. Existing legacy-only `--rss`, `--report`, `--top`, `--push` and custom journal-metrics switches are rejected as `CONFIG_OPTION_UNSUPPORTED` before Zotero sync when used with v2; this avoids an undocumented effective-config merge. P2 will invoke the canonical no-overlay form after E5B enables JSON.
 
 Legacy commands keep those switches unchanged. A future explicit v2 override contract can be versioned separately. E5 may add a legacy `--json` opt-in without changing existing invocations; Basic v2 already requests JSON through `outputs.formats`.
 
@@ -216,7 +223,7 @@ Basic v2 with AI disabled requires only Zotero identity/read credentials. The pa
 
 For every enabled AI route, preflight consults the E2 registry. All E2 preset and Custom protocol entries currently have `adapter_status=unimplemented`, so execution returns `CAPABILITY_UNAVAILABLE` with exit category 3 **before Zotero sync, candidate fetch, model load, or other recommendation side effects**, even when a corresponding fixed slot happens to be populated. E5 does not add AI requests.
 
-Issue precedence is deterministic: config/path invalid → capability unavailable → credential missing/malformed → explicit upstream verification failure. The preflight report can list all sanitized requirement statuses, while the final symbolic error follows that precedence.
+Issue precedence is deterministic: config/path invalid → output/provider capability unavailable → credential missing/malformed → explicit upstream verification failure. The preflight report can list all sanitized requirement statuses, while the final symbolic error follows that precedence. E5A's JSON gate uses `OUTPUT_FORMAT_UNAVAILABLE`; enabled unimplemented AI uses `CAPABILITY_UNAVAILABLE`.
 
 ### 4.3 Commands
 
@@ -267,12 +274,16 @@ Each item contains:
 | `authors` | ordered string array; empty means source supplied no usable authors |
 | `published_at` | UTC RFC 3339 string or null; missing date stays null |
 | `venue` / `url` | string or null |
-| `is_preprint` | boolean or null; known preprint source may yield true, unknown stays null and is never guessed false |
+| `is_preprint` | boolean or null; transported from an explicit adapter/payload field, otherwise null |
 | `score` | finite number; legacy score is not promised to be 0–1 |
 | `score_breakdown` | closed object for the current components |
 | `label` | current deterministic `must_read | consider | ignore` value |
 
-`score_breakdown` has the stable component names `similarity`, `recency`, `metrics`, `author_bonus`, `venue_bonus`, and `journal_quality`. Each is `{value: finite number, input_available: boolean}` so missing metrics/date/SJR are distinct from a real input producing zero. `journal_sjr` is number or null. The projection derives availability from explicit candidate fields and never fabricates missing upstream metrics.
+`score_breakdown` has exactly the seven terms in the current legacy formula: `similarity`, `recency`, `citations`, `altmetric`, `journal_quality`, `author_bonus`, and `venue_bonus`. Each is `{raw_value: finite number, weighted_contribution: finite number, input_available: boolean}`. `journal_sjr` remains number or null as supporting public metadata. Missing citation/altmetric/date/SJR/author/venue input is therefore distinguishable from an available input whose score is zero.
+
+The projector obtains raw values from additive ranking provenance. In particular, E5B adds `altmetric_score` because current `RankedWork.metric_score` preserves only the transformed citation value even though total score includes both citation and altmetric terms. The new provenance is observational: the ranker computes the same seven terms once, stores them, and sums the same weighted contributions in the same order. Tests require `score == sum(weighted_contribution)` within the established floating tolerance and require unchanged total scores/order/goldens.
+
+`CandidateWork.is_preprint` is optional and defaults to null. The public-v1 mapper copies its existing `is_preprint` boolean without coercing missing values; explicit arXiv/bioRxiv/medRxiv adapters set true. Other adapters leave it null unless their upstream protocol supplies an explicit reliable value. The JSON projector never infers false from source absence and never uses title/type/URL heuristics. This metadata transport does not change preprint filtering/ranking in E5; the frozen legacy policy continues to use its existing behavior until separately versioned.
 
 No `metrics` or `extra` object is copied wholesale. `public_id` and any future allowed public field require an explicit projector/schema addition.
 
@@ -401,7 +412,7 @@ Numeric codes stay few and stable:
 Detailed symbolic codes live in the manifest and machine result. Initial closed catalog:
 
 - config: `CONFIG_INVALID`, `CONFIG_MIXED_MODES`, `CONFIG_OPTION_UNSUPPORTED`;
-- preflight: `CAPABILITY_UNAVAILABLE`, `CREDENTIAL_MISSING`, `CREDENTIAL_MALFORMED`, `CREDENTIAL_VERIFICATION_FAILED`;
+- preflight: `OUTPUT_FORMAT_UNAVAILABLE`, `CAPABILITY_UNAVAILABLE`, `CREDENTIAL_MISSING`, `CREDENTIAL_MALFORMED`, `CREDENTIAL_VERIFICATION_FAILED`;
 - sync/state: `ZOTERO_SYNC_FAILED`, `STATE_INCOMPATIBLE`, `STATE_BUILD_FAILED`, `STATE_CORRUPT`;
 - candidates: `CANDIDATE_PARTIAL`, `CANDIDATE_STALE_CACHE`, `CANDIDATE_UNAVAILABLE`, `CANDIDATE_PAYLOAD_INVALID`;
 - execution/output: `DEDUPE_FAILED`, `RANKING_FAILED`, `OUTPUT_CONTRACT_INVALID`, `OUTPUT_RENDER_FAILED`, `OUTPUT_PUBLISH_FAILED`, `ZOTERO_WRITEBACK_FAILED`, `INTERNAL_ERROR`.
@@ -460,8 +471,9 @@ The private run manifest stays in `state/runs/`, outside this publishable tree. 
 6. If legacy Zotero writeback was requested, perform it only after staged output validates and before output publication. A writeback failure does not publish staged reports.
 7. Rename the complete staged directory to immutable `generations/<run-id>` on the same filesystem.
 8. Atomically replace `latest-success.json`. Only a complete validated generation can become authority.
-9. Reconcile each requested stable compatibility path using temp-file + fsync + `os.replace`. Each visible file is therefore either an old complete artifact or a new complete artifact. An interruption can temporarily leave aliases from different **successful** generations, never partial bytes or a failed render; the next invocation repairs aliases from the authoritative pointer before starting a new run.
-10. Finalize the private success manifest and `latest-attempt` pointer.
+9. Finalize the immutable generation artifact list with generation-relative path, SHA-256, size, media type and publishable flag. This list plus the atomic `latest-success` pointer is the machine authority consumed by RunResult/run manifest/P2.
+10. Reconcile each requested stable compatibility path using temp-file + fsync + `os.replace`. Each visible file is therefore either an old complete artifact or a new complete artifact. An interruption can temporarily leave aliases from different **successful** generations, never partial bytes or a failed render; the next invocation repairs aliases from the authoritative pointer before starting a new run.
+11. Finalize the private success manifest and `latest-attempt` pointer.
 
 Unrequested formats are not deleted. P2 uses the current generation's explicit artifact list, so a stale unrequested compatibility file cannot be accidentally published as part of the current run.
 
@@ -489,7 +501,7 @@ RunResult
 
 Python `Path` objects may be absolute in memory for the caller process. Persisted/machine JSON uses only state/report-root relative references.
 
-Add `--machine-result` to the public `zotwatch` entry point. It writes exactly one closed `run-result-v1` JSON object to stdout after finalization; logs remain on stderr. It contains run/status/exit/error and relative manifest/artifact references, not config, profile data or absolute paths. Without the flag, the CLI prints concise human status and returns the same numeric code.
+Add `--machine-result` to the public `zotwatch` entry point. It writes exactly one closed `run-result-v1` JSON object to stdout after finalization; logs remain on stderr. It contains run/status/exit/error and immutable-generation artifact references, not stable aliases, config, profile data or absolute paths. Each P2-facing reference agrees with the finalized artifact whitelist's generation-relative path/hash/size/media type. Without the flag, the CLI prints concise human status and returns the same numeric code.
 
 P2 will only need to invoke the engine, read this machine result, and upload/restore files named by validated contracts. It must not parse logs, inspect Python exception names, derive success from process 0 alone, or scan directories for newest files.
 
@@ -572,7 +584,8 @@ Exact module names may be adjusted during implementation, but config, runtime, r
 | Case | Expected proof |
 | --- | --- |
 | Legacy successful profile/watch | Existing command/config behavior and E0 ranking/RSS/HTML bytes remain unchanged. |
-| Equivalent Basic v2 watch | With identical mirror/candidates/vectorizer/clock, RankedWork order/scores and RSS/HTML bytes equal legacy default; JSON/manifest are additional. |
+| Equivalent Basic v2 watch | E5A uses an RSS/HTML-only v2 fixture; with identical mirror/candidates/vectorizer/clock, RankedWork order/scores and RSS/HTML bytes equal legacy default. E5B adds JSON/manifest. |
+| E5A JSON request | Schema-valid config fails `OUTPUT_FORMAT_UNAVAILABLE`, exit 3, before sync/model/candidate side effects; no JSON file is created. |
 | v2 profile then watch | Both execute E3/E4 rather than return `CONFIG_V2_EXECUTION_DEFERRED`; revision/state handle match. |
 | Mixed config | `CONFIG_MIXED_MODES`, exit 2, no sync/fetch/model load. |
 | v2 legacy-only CLI overlay | `CONFIG_OPTION_UNSUPPORTED`, exit 2 before side effects. |
@@ -582,6 +595,8 @@ Exact module names may be adjusted during implementation, but config, runtime, r
 | Explicit Zotero verification | Read-only bounded check; verified/failed distinct from configured; no SQLite mutation. |
 | Public pool credential | No caller Supabase requirement; packaged connection used and never serialized. |
 | Recommendation JSON golden | Closed schema, deterministic order/ranks/work_key/scores/nulls at frozen time. |
+| Complete score provenance | Seven raw/contribution/availability records reproduce total score within tolerance; added altmetric provenance does not change order or totals. |
+| Explicit preprint metadata | public-v1 true/false is preserved, explicit preprint adapters set true, absent metadata remains null; projector performs no heuristic inference. |
 | Duplicate/missing work identity | Output contract fails; no latest-success replacement. |
 | Publishable JSON leakage | Sentinel Zotero item/profile/key/env/base URL/absolute path/extra data absent from all keys/values. |
 | Successful profile manifest | Only config/preflight/sync/state stages; no fake recommendation artifacts. |
@@ -600,6 +615,7 @@ Exact module names may be adjusted during implementation, but config, runtime, r
 | Manifest/result sanitization | No secret/env name, raw ID/item, endpoint, traceback or absolute path. |
 | Stable exit mapping | Known failures map to 2/3/4/5; detailed distinction remains symbolic. |
 | Wheel/editable/outside checkout | v2 Basic execution, schemas, preflight and machine result work from installed engine. |
+| P2 artifact references | RunResult/manifest references resolve inside immutable selected generation and match whitelist hash/size/media type; aliases are never authoritative inputs. |
 | E3/E4 after E5 failure | SQLite revision/current computational pointer unchanged except a sync already atomically committed before a later-stage failure; stale state is never ranked. |
 | Immutable E0 inputs | `git diff --exit-code --diff-filter=DMR v2-e0-baseline -- tests/goldens tests/fixtures` remains empty. |
 

--- a/E5_IMPLEMENTATION_PLAN.md
+++ b/E5_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,644 @@
+# E5 — Runtime & Result Contract Implementation Plan
+
+日期：2026-09-11
+
+状态：**plan only；等待审阅，尚未修改 production code。**
+
+起点：`v2-e4-baseline` / `5afdaa603ec5e9978ea871505c6233c33e23b7a3`。
+
+## 1. 目标、边界与 PR 拆分决定
+
+E5 是 P2 reusable workflow / thin workspace 前最后一个 engine 阶段。它必须同时关闭两个边界：
+
+1. 让通过 E2 schema/semantic validation 的 **Basic v2** `zotwatch.yaml` 真正进入已有 E3 sync、E4 state、candidate、dedupe、legacy rank 和 output pipeline；
+2. 给该 pipeline 增加 versioned recommendation JSON、private run manifest、稳定 stage/error/exit semantics 和失败安全的 output publication。
+
+分析当前代码后，计划将 E5 实施拆成两个连续、独立审阅的 PR：
+
+- **E5A — Basic v2 runtime bridge & preflight**：只建立 config source → effective runtime mapping、capability/credential preflight 和 v2/legacy 同 pipeline 等价执行；不引入新 result schema，也不改 output publication。
+- **E5B — Result/run contracts & safe publication**：在 E5A 已证明 execution equivalence 后，加入 recommendation/run schemas、stage recorder、symbolic errors、exit policy、candidate outcome metadata 和 output generation publication。
+
+拆分理由是两部分具有不同的 correctness proof。E5A 的核心证据是 legacy/v2 effective settings 与结果内容等价；E5B 的核心证据是任一失败点不会发布混合或失败产物。分开后每个 PR 都可独立回退，也避免在同一 diff 中同时改 config dispatch、全 pipeline orchestration 和全部 writer commit boundary。
+
+**E5A 与 E5B 都属于 E5，且两者必须在进入 P2 前合入、打门禁并封板。** E5A 可使用内部 checkpoint tag `v2-e5a-baseline`；只有 E5B 合入后才创建最终 `v2-e5-baseline`。不把 v2 execution gap、run manifest 或 publication 留给 P2/Web。
+
+E5 不实现 reusable workflow、workspace-template、GitHub artifact/cache transport、Cloudflare、Zotero OAuth、AI 网络 adapter、AI rerank/summary、clustering、新 ranking、durable feedback、harvester 修复或 public candidate API redesign。
+
+## 2. 当前 runtime / output flow
+
+当前 public console entry `zotwatch.cli.main()` 有两条行为：
+
+- `zotwatch config validate` 调用 E2 loader，离线校验 schema/semantics；
+- `profile` / `watch` 先检测 config source。发现 `zotwatch.yaml` 时直接返回 `CONFIG_V2_EXECUTION_DEFERRED`；legacy 时转交 `src.cli.main()`。
+
+Legacy `src.cli.main()` 当前执行：
+
+```text
+resolve workspace/state/reports
+→ load .env
+→ load three legacy YAML files into src.settings.Settings
+→ open profile.sqlite
+→ profile or watch
+→ close SQLite
+```
+
+`profile`：
+
+```text
+acquire E4 run lease
+→ E3 Zotero sync
+→ ensure/build E4 computational generation
+→ release lease
+→ log paths
+```
+
+`watch`：
+
+```text
+acquire E4 run lease
+→ E3 Zotero sync
+→ ensure/build E4 generation
+→ fetch candidates using the same profile summary
+→ dedupe against the committed mirror
+→ rank with the same StateHandle
+→ release lease
+→ seven-day filter
+→ legacy preprint cap
+→ top limit
+→ optionally write feed.xml
+→ optionally write one dated/empty HTML file
+→ optionally push to Zotero
+```
+
+Current output and error limitations:
+
+- RSS/HTML writers write directly to stable paths. If a later writer or Zotero push fails, earlier files may already have replaced known-good output.
+- There is no public recommendation JSON or private operational run manifest.
+- Candidate source failures are reduced to log messages plus a list; callers cannot distinguish a complete empty result, a partial result, or stale-cache fallback.
+- Successful functions return `None`; P2 would have to parse logs and guess artifact paths/status.
+- `argparse` gives parse/config failures code 2, while most runtime exceptions escape and normally become process code 1. There is no stable runtime category or symbolic error.
+- Config/capability/credential failures do not produce a sanitized machine-readable record.
+- E4 computational-state generations are atomic, but report files have no analogous run generation or success pointer.
+
+## 3. E5A: one effective runtime model, one pipeline
+
+### 3.1 Data model and ownership
+
+Add an internal, immutable `EffectiveRuntimeConfig` that contains only values consumed by the implemented pipeline:
+
+```text
+EffectiveRuntimeConfig
+  source: legacy | v2
+  config_schema_version: null | 2
+  config_fingerprint_sha256
+  settings: src.settings.Settings
+  embedding_provider/model
+  ranking_policy
+  top_n
+  max_preprint_ratio
+  output_formats
+  publish_requested
+  feature_routes
+  compatibility flags
+```
+
+`src.settings.Settings` remains the compatibility shape consumed by E3/E4/fetch/ranker. The new adapter owns construction of that shape; production modules do not inspect YAML source or implement a second v2 pipeline. Runtime-only values that do not belong in legacy `Settings` remain on `EffectiveRuntimeConfig`.
+
+`ExecutionRequest` holds command-line run choices separately from Git config:
+
+```text
+command: profile | watch
+full / weekly
+workspace/state/reports paths
+strict
+legacy rss/report/top/push switches
+journal metrics selection
+machine-result mode
+```
+
+The loader calls `detect_config_source()` exactly once. A workspace containing both modes still fails with `CONFIG_MIXED_MODES`; no field-level merge, fallback, or “prefer v2” behavior is allowed.
+
+### 3.2 Legacy mapping boundary
+
+Legacy runtime continues to use `LegacyConfigAdapter.load().settings` without round-tripping through the lossy legacy → v2 projection. `LegacyMappingReport` remains a migration/reporting aid and never becomes execution authority.
+
+For legacy invocations:
+
+- the existing three files, `${ENV}` expansion, fixed Secret names, advanced public endpoint/key override, source fallbacks, scoring customization and direct-fetch mode continue to work;
+- `python -m src.cli ...` remains a compatibility entry point;
+- existing `--rss`, `--report`, `--top`, `--push`, `--full`, `--weekly`, path and journal-metrics behavior remains accepted;
+- existing RSS GUID and HTML content/path tests remain authoritative.
+
+Shared runtime functions may return richer internal results, but the compatibility wrapper preserves legacy success behavior and does not require conversion to `zotwatch.yaml`.
+
+### 3.3 Basic v2 → runtime mapping
+
+E5A accepts only the capabilities already constrained by config schema v2:
+
+| v2 field | Effective runtime mapping |
+| --- | --- |
+| `zotero.library_type=user` | Existing E3 user-library ingestor. User ID and API key come from engine-owned fixed Zotero credential definitions; YAML contains neither name nor value. |
+| `candidates.provider=public-api-v1` | `PublicCandidatesApiConfig(enabled=true)` populated from packaged `PublicCandidateConnection`; caller supplies no Supabase key/endpoint. |
+| `candidates.sources` | Existing source enable flags used by `CandidateFetcher`, preserving the current public-v1 request and validated legacy top-venue compatibility path. |
+| `candidates.window_days=7` | Existing seven-day fetch/filter policy. |
+| `embedding.provider=local` and fixed model | Existing `TextVectorizer`; no remote embedding/provider adapter. |
+| `ranking.policy=legacy-v1` | Exact frozen legacy weights, thresholds, decay rules and whitelist defaults used by the ordinary legacy projection. No scoring formula changes. |
+| `ranking.top_n` | Run top limit when no legacy compatibility wrapper is involved. |
+| `ranking.max_preprint_ratio=0.3` | Existing deterministic `_limit_preprints` policy. |
+| `outputs.formats` | Requested local render set for v2 `watch`; `profile` produces no recommendation outputs. |
+| `outputs.publish` | Recorded publish intent only. E5 performs no Pages/GitHub publication; P2 consumes this flag. |
+| disabled AI features | No route, credential or network requirement. |
+
+The v2 adapter uses the packaged journal/SJR resource, so an independent thin workspace does not need an engine source `data/journal_metrics.csv`. The packaged public connection is copied into an existing runtime settings object without exposing its publishable key in config, logs, repr, result, or manifest.
+
+The fixed legacy-v1 scoring values live in one runtime-policy constant/module. E5A will remove duplicate numeric definitions between legacy projection and v2 runtime construction by importing that single constant; this is metadata consolidation, not a scoring change.
+
+### 3.4 CLI option rules for v2
+
+Canonical v2 execution is:
+
+```text
+zotwatch profile --workspace <workspace> [--full|--weekly]
+zotwatch watch --workspace <workspace> [--strict]
+```
+
+For v2 `watch`, `top_n`, preprint ratio and output formats come from `zotwatch.yaml`. Existing legacy-only `--rss`, `--report`, `--top`, `--push` and custom journal-metrics switches are rejected as `CONFIG_OPTION_UNSUPPORTED` before Zotero sync when used with v2; this avoids an undocumented effective-config merge. P2 will invoke the canonical no-overlay form.
+
+Legacy commands keep those switches unchanged. A future explicit v2 override contract can be versioned separately. E5 may add a legacy `--json` opt-in without changing existing invocations; Basic v2 already requests JSON through `outputs.formats`.
+
+`outputs.publish` does not cause network publication in E5. It only appears as sanitized run intent so P2 can decide whether to publish the output-generation whitelist.
+
+### 3.5 Side-effect ordering
+
+The public coordinator resolves paths, detects/loads config, resolves routes, and completes preflight before opening a write transaction, contacting Zotero/public candidates, loading the vector model, or creating a computational generation.
+
+Writing a private failed run manifest after valid state/report paths are known is allowed and is not considered recommendation-pipeline side effect. A malformed path request that prevents resolving a safe state directory cannot promise a manifest; it still returns the stable config/path exit category.
+
+After preflight, both sources enter the same existing functions:
+
+```text
+EffectiveRuntimeConfig + ExecutionRequest
+→ E3 sync
+→ E4 ensure/build
+→ CandidateFetcher
+→ DedupeEngine
+→ WorkRanker
+→ current filters
+→ E5 output coordinator
+```
+
+No v2-specific sync, state builder, fetcher, deduper, ranker, writer, cache, or SQLite schema is introduced.
+
+## 4. Credential/runtime preflight
+
+### 4.1 Three independent facts
+
+Preflight reports these separately for each requirement:
+
+- `configured`: the fixed engine-owned credential slot has a non-empty runtime value with the expected coarse shape;
+- `runtime_supported`: the selected provider/protocol adapter is implemented in this engine revision;
+- `verification`: `not_requested | verified | failed | unsupported` for an explicit upstream check.
+
+“Secret exists” is never worded as “credential is valid.” Default preflight is offline and sets upstream verification to `not_requested`.
+
+### 4.2 Fixed requirements and redacted output
+
+The engine registry owns fixed runtime lookups for:
+
+- Zotero user-library identity;
+- Zotero API credential;
+- preset provider credentials;
+- `custom-1` … `custom-4` structured credential slots.
+
+Config and machine output use safe requirement IDs such as `zotero.identity`, `zotero.read`, `feature.rerank`, and `feature.summary`. They never emit environment names, GitHub Secret names, credential values, Custom base URLs, or complete service records.
+
+Basic v2 with AI disabled requires only Zotero identity/read credentials. The packaged public pool connection is an engine dependency, not a user credential requirement; preflight explicitly reports `user_credential_required=false` without printing the internal key.
+
+For every enabled AI route, preflight consults the E2 registry. All E2 preset and Custom protocol entries currently have `adapter_status=unimplemented`, so execution returns `CAPABILITY_UNAVAILABLE` with exit category 3 **before Zotero sync, candidate fetch, model load, or other recommendation side effects**, even when a corresponding fixed slot happens to be populated. E5 does not add AI requests.
+
+Issue precedence is deterministic: config/path invalid → capability unavailable → credential missing/malformed → explicit upstream verification failure. The preflight report can list all sanitized requirement statuses, while the final symbolic error follows that precedence.
+
+### 4.3 Commands
+
+Keep `zotwatch config validate` strictly offline and schema/semantic only. Add:
+
+```text
+zotwatch runtime preflight --workspace <path> [--json]
+zotwatch runtime preflight --workspace <path> --verify-zotero [--json]
+```
+
+The default command only checks presence/shape and registry status. `--verify-zotero` performs one bounded, read-only Zotero authentication/library-identity request, never syncs SQLite, and is the only E5 live credential check. AI upstream verification remains `unsupported` until an adapter exists; E5 must not implement an AI call for validation. Public-pool reachability belongs to candidate execution status rather than user credential validity.
+
+Human output uses fixed sanitized messages. JSON output has a version, overall readiness, requirement IDs and the three fields above. It excludes values and lookup names.
+
+## 5. E5B recommendation JSON contract
+
+### 5.1 Path and top-level schema
+
+Publishable artifact path: `reports/recommendations.json`. Schema owner is ZotWatch; first schema version is integer `1`.
+
+```json
+{
+  "schema_version": 1,
+  "run_id": "0199...",
+  "generated_at": "2026-09-11T07:00:00Z",
+  "count": 2,
+  "items": []
+}
+```
+
+Top-level fields are closed (`additionalProperties=false`). `count` must equal `items.length`; item order is recommendation order and `rank` is contiguous from 1. `generated_at` is one UTC run timestamp, not each writer's wall clock.
+
+Do not serialize `RankedWork.model_dump()` directly. A dedicated projection model explicitly copies allowed fields and rejects unexpected fields.
+
+### 5.2 Item schema and null semantics
+
+Each item contains:
+
+| Field | Type / rule |
+| --- | --- |
+| `rank` | integer >= 1; position in `items` |
+| `work_key` | stable identity described below; never rank-based |
+| `source` / `source_identifier` | required non-empty strings; retain source identity |
+| `public_id` | string or null; only a public-pool row aid, not canonical identity |
+| `doi` | normalized DOI string or null |
+| `title` | required string |
+| `abstract` | literature-content string or null |
+| `authors` | ordered string array; empty means source supplied no usable authors |
+| `published_at` | UTC RFC 3339 string or null; missing date stays null |
+| `venue` / `url` | string or null |
+| `is_preprint` | boolean or null; known preprint source may yield true, unknown stays null and is never guessed false |
+| `score` | finite number; legacy score is not promised to be 0–1 |
+| `score_breakdown` | closed object for the current components |
+| `label` | current deterministic `must_read | consider | ignore` value |
+
+`score_breakdown` has the stable component names `similarity`, `recency`, `metrics`, `author_bonus`, `venue_bonus`, and `journal_quality`. Each is `{value: finite number, input_available: boolean}` so missing metrics/date/SJR are distinct from a real input producing zero. `journal_sjr` is number or null. The projection derives availability from explicit candidate fields and never fabricates missing upstream metrics.
+
+No `metrics` or `extra` object is copied wholesale. `public_id` and any future allowed public field require an explicit projector/schema addition.
+
+### 5.3 Stable work identity
+
+`work_key` follows the state/feedback contract:
+
+1. If a valid DOI is present, normalize Unicode/whitespace, remove DOI URL/prefix, lowercase the DOI canonical form, and emit `doi:<canonical-doi>`.
+2. Otherwise emit `source:<normalized-source>:<normalized-source-identifier>`. Source is lowercase; identifier is Unicode-normalized and trimmed but retains source-defined case/content.
+
+The mapper rejects empty fallback identity. Within one recommendation document, `work_key` must be unique; a collision is an output-contract failure, never repaired with rank or random suffix.
+
+### 5.4 Public safety boundary
+
+Recommendation JSON may later be selected for Pages publication, so it may include only public bibliographic candidate data and derived recommendation scores. It must never include:
+
+- Zotero library items, raw user/library ID, profile centroid, private authors/venues/tags or library identity fingerprint;
+- credentials, env/Secret names, Custom connection ID/base URL or complete model/service config;
+- absolute paths, request headers/body, traceback, candidate cache internals, or arbitrary `extra` fields.
+
+Abstract/title/author strings remain untrusted literature data. JSON encoding must preserve them as data, and HTML consumers must escape them. A leakage test walks keys and values using sentinel private/secret/path values, not only a hand-maintained top-level key list.
+
+## 6. Private run manifest contract
+
+### 6.1 Location and purpose
+
+Private operational manifests live under the state root:
+
+```text
+state/runs/<run-id>/run-manifest.json
+state/runs/latest-attempt.json
+```
+
+They are not placed in `reports/` and are never part of the Pages publication whitelist. `latest-attempt.json` is an atomic pointer to the most recently finalized attempt, including failure; successful recommendation publication has a separate pointer under reports.
+
+A config failure produces a manifest when workspace/state paths were safely resolved and the run directory could be created. Parser/path failures before that boundary only guarantee stderr + exit code.
+
+### 6.2 Proposed v1 fields
+
+```json
+{
+  "schema_version": 1,
+  "run_id": "0199...",
+  "request_id": null,
+  "engine": {
+    "version": "2.0.0.dev1",
+    "revision": null
+  },
+  "command": "watch",
+  "mode": "incremental",
+  "config": {
+    "source": "v2",
+    "schema_version": 2,
+    "fingerprint_sha256": "..."
+  },
+  "started_at": "...Z",
+  "finished_at": "...Z",
+  "status": "succeeded",
+  "state": {
+    "generation_id": "...",
+    "library_revision": 132,
+    "library_identity_sha256": "..."
+  },
+  "requested_outputs": ["json", "rss", "html"],
+  "publish_requested": false,
+  "stages": [],
+  "candidate_pool": {},
+  "artifacts": [],
+  "error": null
+}
+```
+
+Rules:
+
+- `engine.version` is required. `engine.revision` is nullable because an installed wheel cannot reliably infer a Git commit. P2 may inject its verified `job.workflow_sha` through an engine-owned invocation channel; E5 does not guess or claim workflow identity.
+- `config.fingerprint_sha256` hashes a canonical **sanitized execution-semantic projection**. It excludes Custom base URLs, credential material, service records and fields irrelevant to the current implemented Basic route. P2 may separately associate a Git blob SHA without serializing the config.
+- `state` values are null until E4 state succeeds. Library identity is already pseudonymous but remains private operational metadata.
+- artifact references use state-root/report-root relative paths, media type, byte length, SHA-256 and `publishable` boolean. No absolute path is serialized.
+- final manifest stages cannot remain `pending` or `running`.
+- top-level `error` is null on succeeded/degraded runs; failed runs contain one symbolic code, sanitized catalog message and opaque diagnostic ID. It never contains exception type, traceback, raw exception string or request/config content.
+
+`profile` manifests contain config/preflight/sync/state stages and no recommendation artifacts. `watch` manifests include the full execution stages.
+
+## 7. Stable stage and status model
+
+Public stage IDs are a finite vocabulary owned by the result schema, not Python function names:
+
+| Stage ID | Meaning |
+| --- | --- |
+| `config_validation` | path/source detection, parse, schema/semantic checks, effective mapping |
+| `credential_preflight` | runtime adapter support and credential readiness |
+| `zotero_sync` | E3 acquisition + atomic SQLite commit |
+| `computational_state` | E4 reuse/build/validation |
+| `candidate_fetch` | public/legacy candidate acquisition and cache fallback |
+| `dedupe` | remove items matching personal mirror |
+| `ranking` | existing scoring plus current recency/preprint/top policy |
+| `output_render` | build and validate all requested output-generation files |
+| `zotero_writeback` | legacy optional `--push`; skipped for Basic v2 |
+| `output_publish` | switch successful output generation and compatibility aliases |
+
+Stage status enum: `pending | running | succeeded | skipped | degraded | failed`. Overall run status: `succeeded | degraded | failed`.
+
+Finalization invariants:
+
+- overall `succeeded`: every required stage succeeded or was intentionally skipped; no degraded/failed stage;
+- overall `degraded`: no required stage failed, at least one allowed fallback/partial stage degraded;
+- overall `failed`: one required stage failed; later unstarted stages finalize as skipped with no fabricated timestamps/errors;
+- only the failing/degraded stage carries its stage symbolic error; exception class names never enter the contract;
+- empty candidates after a complete successful request can be succeeded with count 0;
+- public request failure with an allowed fresh-enough stale cache is degraded;
+- all candidate acquisition unavailable with no allowed cache is failed, not successful empty output;
+- strict mode converts a publishable degraded computation into exit 5 and prevents updating latest-success outputs, while retaining the private degraded manifest.
+
+## 8. Symbolic error and numeric exit policy
+
+Numeric codes stay few and stable:
+
+| Exit | Category | Examples |
+| --- | --- | --- |
+| `0` | completed | overall succeeded or allowed degraded |
+| `2` | configuration/path | invalid/mixed config, unsupported v2 CLI overlay, invalid paths/schema |
+| `3` | capability/credential dependency | adapter unavailable, required fixed credential absent/malformed, explicit credential verification failed |
+| `4` | runtime execution | sync/state/candidate/ranking/render/publication/writeback/unexpected failure |
+| `5` | strict degradation | usable degraded result recorded, but stable successful outputs not updated |
+
+Detailed symbolic codes live in the manifest and machine result. Initial closed catalog:
+
+- config: `CONFIG_INVALID`, `CONFIG_MIXED_MODES`, `CONFIG_OPTION_UNSUPPORTED`;
+- preflight: `CAPABILITY_UNAVAILABLE`, `CREDENTIAL_MISSING`, `CREDENTIAL_MALFORMED`, `CREDENTIAL_VERIFICATION_FAILED`;
+- sync/state: `ZOTERO_SYNC_FAILED`, `STATE_INCOMPATIBLE`, `STATE_BUILD_FAILED`, `STATE_CORRUPT`;
+- candidates: `CANDIDATE_PARTIAL`, `CANDIDATE_STALE_CACHE`, `CANDIDATE_UNAVAILABLE`, `CANDIDATE_PAYLOAD_INVALID`;
+- execution/output: `DEDUPE_FAILED`, `RANKING_FAILED`, `OUTPUT_CONTRACT_INVALID`, `OUTPUT_RENDER_FAILED`, `OUTPUT_PUBLISH_FAILED`, `ZOTERO_WRITEBACK_FAILED`, `INTERNAL_ERROR`.
+
+One central mapper translates known typed boundary exceptions to this catalog. Unknown exceptions map to `INTERNAL_ERROR`; they do not create permanent numeric codes. Sanitized messages are fixed by code and may mention stage/diagnostic ID, never raw remote/config/credential content.
+
+`zotwatch` returns these codes. The legacy module entry point remains available; where exact historical exception behavior is relied on, its wrapper may retain it while still delegating successful work to shared orchestration. P2 must invoke `zotwatch`, not parse legacy traceback behavior.
+
+## 9. Candidate/harvester failure boundary
+
+E5B introduces a `CandidateFetchOutcome` alongside the candidate list:
+
+```text
+candidates
+status: succeeded | degraded | failed
+used_cache
+cache_age/fetched_at when safe
+requested window_days
+request_complete
+source outcomes with stable source IDs/status/error code
+```
+
+For compatibility, `CandidateFetcher.fetch_all()` continues returning `list[CandidateWork]`. The coordinator uses a new `fetch_with_outcome()` API; both share the same current fetching/cache implementation. This adds observability and terminal all-source failure handling without changing Crossref pagination, source mapping, retention, OpenAlex behavior, direct top-venue compatibility or the public v1 protocol.
+
+`request_complete=true` means only that the engine finished the bounded request under the current v1 protocol and budgets. It does not claim cross-source completeness, freshness beyond observed timestamps, canonical deduplication, or reliable long-term incremental semantics. H1–H3 remain separate.
+
+## 10. Output generation/publication lifecycle
+
+### 10.1 Layout
+
+```text
+reports/
+  recommendations.json                 # stable compatibility/public path
+  feed.xml                             # existing stable RSS path
+  report.html                          # new stable HTML path
+  report-YYYYMMDD.html                 # existing dated compatibility path
+  report-empty.html                    # existing empty compatibility path
+  .zotwatch-output/
+    latest-success.json                # atomic authoritative pointer
+    generations/<run-id>/
+      recommendations.json             # if requested
+      feed.xml                          # if requested
+      report.html                       # if requested
+    staging/<run-id>.tmp/
+```
+
+The private run manifest stays in `state/runs/`, outside this publishable tree. P2 publishes only files explicitly listed `publishable=true` from the successful output generation; it never copies `.zotwatch-output`, state, or the whole reports directory.
+
+### 10.2 Lifecycle
+
+1. Rank/filter/top completes in memory.
+2. Create run-scoped staging under the reports filesystem.
+3. Render every requested JSON/RSS/HTML file with one `run_id/generated_at` context. Existing RSS and dated/empty HTML writers retain byte-compatible content for E0 frozen time.
+4. Parse/validate JSON schema, XML structure, UTF-8 HTML and artifact allowlist; compute hashes/sizes.
+5. If any render/validation fails, delete/ignore staging, write a private failed manifest, and leave current pointer plus all stable files untouched.
+6. If legacy Zotero writeback was requested, perform it only after staged output validates and before output publication. A writeback failure does not publish staged reports.
+7. Rename the complete staged directory to immutable `generations/<run-id>` on the same filesystem.
+8. Atomically replace `latest-success.json`. Only a complete validated generation can become authority.
+9. Reconcile each requested stable compatibility path using temp-file + fsync + `os.replace`. Each visible file is therefore either an old complete artifact or a new complete artifact. An interruption can temporarily leave aliases from different **successful** generations, never partial bytes or a failed render; the next invocation repairs aliases from the authoritative pointer before starting a new run.
+10. Finalize the private success manifest and `latest-attempt` pointer.
+
+Unrequested formats are not deleted. P2 uses the current generation's explicit artifact list, so a stale unrequested compatibility file cannot be accidentally published as part of the current run.
+
+Empty recommendations are a valid complete generation and may atomically replace previous outputs when candidate acquisition itself succeeded. A failed/unknown empty acquisition cannot.
+
+This design avoids pretending multi-file paths provide cross-filesystem ACID. The single authoritative pointer is atomic; compatibility aliases are independently atomic and recoverable.
+
+## 11. RunResult API and P2 handoff
+
+Internal orchestration returns:
+
+```text
+RunResult
+  run_id
+  status
+  exit_code
+  error_code / sanitized_message / diagnostic_id
+  manifest_path
+  output_generation_id
+  recommendation_json_path
+  rss_path
+  html_path
+  state_generation_id
+```
+
+Python `Path` objects may be absolute in memory for the caller process. Persisted/machine JSON uses only state/report-root relative references.
+
+Add `--machine-result` to the public `zotwatch` entry point. It writes exactly one closed `run-result-v1` JSON object to stdout after finalization; logs remain on stderr. It contains run/status/exit/error and relative manifest/artifact references, not config, profile data or absolute paths. Without the flag, the CLI prints concise human status and returns the same numeric code.
+
+P2 will only need to invoke the engine, read this machine result, and upload/restore files named by validated contracts. It must not parse logs, inspect Python exception names, derive success from process 0 alone, or scan directories for newest files.
+
+## 12. Privacy and sanitization rules
+
+Three output classes remain distinct:
+
+| Class | Location | Publication |
+| --- | --- | --- |
+| Publishable recommendation output | current successful report generation + stable aliases | only when user/P2 explicitly opts in and only allowlisted fields/files |
+| Private operational result | `state/runs/<run-id>` | private artifact/status input only |
+| Rebuildable computational state | E4 SQLite/generations/cache | private state artifact later; never report/Pages/Git |
+
+Neither public nor private E5 result serializes credential values/names, raw Zotero user ID/item data, Custom endpoint, full service config, absolute path, full environment, request body/header, exception repr or traceback.
+
+Model strings are user-controlled for registered future services. Until AI execution exists, a failed capability manifest records provider category/feature and null model; it does not echo arbitrary model input. Custom is recorded only as provider `custom` plus safe feature/protocol capability if needed, never connection/base URL.
+
+## 13. Backward compatibility
+
+E5 must preserve:
+
+- E0 RSS GUID and complete RSS/HTML goldens;
+- legacy dated and empty HTML paths plus `reports/feed.xml`;
+- E1 wheel/editable/outside-checkout execution and packaged resources;
+- E2 strict schema, registry single source of truth, mixed-mode rejection and offline config validation;
+- E3 revision/trash/atomic SQLite semantics and credential slot names;
+- E4 state manifest/generation/lease invariants and ranker's validated StateHandle;
+- legacy config execution, advanced self-hosted public override and no forced migration;
+- Basic mode without any AI credential;
+- current scoring formula, ranking order and candidate fetch/direct top-venue behavior except the explicit all-unavailable failure classification.
+
+Intentional E5 changes:
+
+- Basic v2 `profile/watch` become executable;
+- unsupported enabled AI fails capability preflight before recommendation side effects;
+- requested JSON and private manifests are added;
+- public `zotwatch` gains stable exit/error semantics;
+- complete empty candidate results are distinguishable from unavailable acquisition;
+- failed/degraded-strict runs do not replace latest successful reports;
+- v2 config, rather than legacy-only CLI flags, owns Basic top/output choices.
+
+No E0 fixture/golden is rewritten to hide these changes. New JSON/run contracts receive separate E5 fixtures/goldens.
+
+## 14. Expected modified files
+
+Plan-only commit changes only this file. After approval, expected implementation files are:
+
+### E5A
+
+- `zotwatch/runtime/config.py` — `EffectiveRuntimeConfig`, one source detector/adapter and v2 Basic mapping.
+- `zotwatch/runtime/preflight.py` — fixed-slot presence/runtime support and optional Zotero live verification.
+- `zotwatch/runtime/models.py` — request/preflight typed internal models.
+- `zotwatch/cli.py` — public dispatch, preflight command, v2 execution, stable early exits.
+- `zotwatch/config/legacy.py` — import shared legacy-v1 policy metadata; no legacy execution projection.
+- `zotwatch/providers/registry.py` / `credentials.py` — expose fixed lookup through a non-secret runtime API, without duplicating registry lists.
+- `src/cli.py` — extract shared profile/watch coordinator callable while preserving module CLI wrapper.
+- `pyproject.toml` — package the new `zotwatch.runtime` package.
+- `tests/test_runtime_config_e5.py`, `tests/test_runtime_preflight_e5.py`, `tests/test_runtime_equivalence_e5.py`.
+- installed probes, packaging CI and test documentation needed to prove checkout-independent v2 execution.
+
+### E5B
+
+- `zotwatch/results/models.py` — recommendation/run/stage/artifact/RunResult contract models.
+- `zotwatch/results/errors.py` — closed symbolic catalog and exception-boundary mapping.
+- `zotwatch/results/recorder.py` — stage lifecycle and private manifest finalization.
+- `zotwatch/results/publication.py` — output staging, schema validation, generation pointer and alias recovery.
+- `zotwatch/resources/recommendations-v1.schema.json`.
+- `zotwatch/resources/run-manifest-v1.schema.json`.
+- `zotwatch/resources/run-result-v1.schema.json` and optional preflight schema if CLI JSON is public.
+- `src/cli.py` / `zotwatch/cli.py` — stage-aware orchestration and machine result output.
+- `src/fetch_new.py` — additive `fetch_with_outcome()` metadata; existing `fetch_all()` compatibility wrapper retained.
+- `src/rss_writer.py` / `src/report_html.py` — accept shared render context or staging paths without changing legacy rendered bytes.
+- `pyproject.toml`, `.gitignore`, packaging checks and E5 docs.
+- `tests/test_recommendation_contract_e5.py`, `tests/test_run_manifest_e5.py`, `tests/test_output_publication_e5.py`, `tests/test_exit_codes_e5.py`, plus focused updates to existing CLI/pipeline/install tests.
+
+Exact module names may be adjusted during implementation, but config, runtime, result-contract and writer responsibilities must remain separated.
+
+## 15. Regression / acceptance matrix
+
+| Case | Expected proof |
+| --- | --- |
+| Legacy successful profile/watch | Existing command/config behavior and E0 ranking/RSS/HTML bytes remain unchanged. |
+| Equivalent Basic v2 watch | With identical mirror/candidates/vectorizer/clock, RankedWork order/scores and RSS/HTML bytes equal legacy default; JSON/manifest are additional. |
+| v2 profile then watch | Both execute E3/E4 rather than return `CONFIG_V2_EXECUTION_DEFERRED`; revision/state handle match. |
+| Mixed config | `CONFIG_MIXED_MODES`, exit 2, no sync/fetch/model load. |
+| v2 legacy-only CLI overlay | `CONFIG_OPTION_UNSUPPORTED`, exit 2 before side effects. |
+| Enabled preset/Custom AI route | Schema remains valid; preflight returns `CAPABILITY_UNAVAILABLE`, exit 3, no Zotero/candidate/AI call. |
+| Missing Zotero identity/key | Machine-readable configured=false, verification=not_requested, exit 3; no value/lookup name leaked. |
+| Basic no AI key | Preflight ready and profile/watch may run. |
+| Explicit Zotero verification | Read-only bounded check; verified/failed distinct from configured; no SQLite mutation. |
+| Public pool credential | No caller Supabase requirement; packaged connection used and never serialized. |
+| Recommendation JSON golden | Closed schema, deterministic order/ranks/work_key/scores/nulls at frozen time. |
+| Duplicate/missing work identity | Output contract fails; no latest-success replacement. |
+| Publishable JSON leakage | Sentinel Zotero item/profile/key/env/base URL/absolute path/extra data absent from all keys/values. |
+| Successful profile manifest | Only config/preflight/sync/state stages; no fake recommendation artifacts. |
+| Successful watch manifest | All required fields/stages/counts/state generation/artifacts agree. |
+| Config failure manifest | Produced when paths are valid; sanitized error, later stages skipped, exit 2. |
+| Sync/state failure | Correct stage/error/exit 4; E4 previous generation remains and latest reports unchanged. |
+| Candidate complete empty | succeeded, count 0, requested empty outputs may publish. |
+| Candidate partial/stale cache | degraded status and symbolic reason; exit 0 normally, exit 5 strict without publication. |
+| Candidate unavailable no cache | failed, no successful empty report, previous outputs preserved. |
+| Dedupe/ranking failure | Correct stable symbolic code, no new output generation/pointer. |
+| JSON/RSS/HTML render failure | Staging ignored/removed; all previous stable aliases and success pointer unchanged. |
+| Interruption before generation rename | Staging never selected; recovery ignores/removes it. |
+| Interruption after success pointer | Every alias remains complete old/new; next run reconciles aliases from pointer. |
+| Legacy Zotero push failure | Validated staging not published; previous outputs preserved. |
+| Unrequested format | Previous compatibility file not deleted and current artifact whitelist omits it. |
+| Manifest/result sanitization | No secret/env name, raw ID/item, endpoint, traceback or absolute path. |
+| Stable exit mapping | Known failures map to 2/3/4/5; detailed distinction remains symbolic. |
+| Wheel/editable/outside checkout | v2 Basic execution, schemas, preflight and machine result work from installed engine. |
+| E3/E4 after E5 failure | SQLite revision/current computational pointer unchanged except a sync already atomically committed before a later-stage failure; stale state is never ranked. |
+| Immutable E0 inputs | `git diff --exit-code --diff-filter=DMR v2-e0-baseline -- tests/goldens tests/fixtures` remains empty. |
+
+Tests use frozen Zotero/public fixtures, fixed vectorizer and clock; live credential verification is unit-tested with HTTP fakes. No test contacts an upstream service.
+
+## 16. Implementation commits and PR boundaries
+
+### Plan commit
+
+1. `docs: plan E5 runtime and result contracts` — this file only.
+
+### E5A PR
+
+1. `test(runtime): define E5A v2 execution and preflight regressions` — failing tests plus red evidence against `v2-e4-baseline`.
+2. `feat(config): map Basic v2 to effective runtime settings` — one adapter, packaged public connection, shared policy metadata.
+3. `feat(runtime): add capability and credential preflight` — offline/default and explicit fake-tested Zotero verification.
+4. `feat(cli): execute v2 and legacy through one coordinator` — preserve module CLI, reject unsupported v2 overlays before side effects.
+5. `test(runtime): seal E5A equivalence and installation gates` — equivalent legacy/v2 fixtures, wheel/editable/CI/docs.
+
+E5A is merged independently after E0–E4 plus E5A gates pass. Record merge SHA; optional annotated checkpoint `v2-e5a-baseline`.
+
+### E5B PR
+
+1. `test(results): define E5B contract and publication regressions` — failing schemas/stage/error/failure-boundary tests and red evidence on E5A baseline.
+2. `feat(results): add recommendation and private run contracts` — versioned schemas/models/projectors/recorder.
+3. `feat(runtime): report stages, candidate outcomes, and stable exits` — central coordinator/error mapper/RunResult.
+4. `feat(outputs): publish validated output generations safely` — staging, immutable generation, pointer, atomic aliases and recovery.
+5. `test(results): seal E5 output, privacy, and installation gates` — goldens, failure injection, packages/docs/CI.
+
+E5B is merged only after E0–E5 gates pass and E0 goldens remain unchanged. Its merge SHA becomes the final E5 baseline and receives annotated tag `v2-e5-baseline`. P2 starts only from that SHA.
+
+No commit combines E5 changes with reusable workflow, template, GitHub artifact transport, AI, candidate/harvester fixes or scoring changes.
+
+## 17. Rollback strategy
+
+Rolling back E5A to `v2-e4-baseline` restores the deliberate v2 execution-deferred behavior while leaving legacy execution and E3/E4 state readable. It writes no new persistent schema that E4 must understand.
+
+Rolling back E5B to E5A leaves E3 SQLite and E4 computational generations untouched. Older engines ignore `state/runs/` and report output-generation directories. Stable legacy `feed.xml` and dated/empty HTML files remain ordinary complete files; an E5A/legacy run may overwrite them using its old writer behavior.
+
+E5 never migrates or deletes durable feedback. Failed/interrupted E5 runs may leave inert staging or immutable unreferenced output generations, which are safe to delete. Rollback never selects them by directory timestamp.
+
+If an E5 result schema must change incompatibly, increment its schema version; do not reinterpret or rewrite old private manifests/recommendation JSON in place. P2 pins the final E5 engine SHA and consumes only declared compatible versions.

--- a/docs/E5A_RUNTIME.md
+++ b/docs/E5A_RUNTIME.md
@@ -1,0 +1,28 @@
+# E5A — Basic v2 Runtime Bridge
+
+E5A maps a validated Basic v2 `zotwatch.yaml` into the existing E3 sync, E4
+computational-state, candidate, dedupe, ranking, RSS, and HTML pipeline. Legacy
+configuration continues through its existing entry point. The two configuration
+sources are detected explicitly and are never merged.
+
+The runtime preflight completes before Zotero synchronization, model loading,
+candidate networking, or computational-state generation. It separates whether a
+fixed credential requirement is configured, whether the selected capability has
+an implemented runtime adapter, and whether an optional upstream verification was
+requested. Its diagnostics contain stable requirement IDs and do not expose
+credential values, environment names, GitHub Secret names, Custom base URLs, or
+complete service records.
+
+At the E5A checkpoint, RSS and HTML are executable output formats. A v2 request
+for JSON fails with `OUTPUT_FORMAT_UNAVAILABLE` and exit category 3 during
+preflight. E5B owns the versioned JSON result contract and will enable that
+capability.
+
+Basic v2 uses the single legacy-v1 scoring policy constant and the bundled
+journal metrics resource. Regression coverage compares the complete ranked
+objects and RSS/HTML bytes for equivalent default legacy and Basic v2 runs. It
+does not change sync, state, candidate fetching, dedupe, scoring formulas,
+filters, ordering, or writer behavior.
+
+The E5A gate includes source, wheel, editable-install, config, characterization,
+and installation probes. E0 fixtures and goldens remain byte-for-byte unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ Repository = "https://github.com/Yorks0n/ZotWatch"
 zotwatch = "zotwatch.cli:main"
 
 [tool.setuptools]
-packages = ["src", "zotwatch", "zotwatch.config", "zotwatch.providers", "zotwatch.resources"]
+packages = ["src", "zotwatch", "zotwatch.config", "zotwatch.providers", "zotwatch.resources", "zotwatch.runtime"]
 include-package-data = false
 
 [tool.setuptools.package-data]

--- a/tests/E5A_RED_BASELINE.md
+++ b/tests/E5A_RED_BASELINE.md
@@ -1,0 +1,14 @@
+# E5A expected-red baseline
+
+Starting production is exactly `v2-e4-baseline` (`5afdaa603ec5e9978ea871505c6233c33e23b7a3`). The approved E5 plan/clarifications and these runtime regression tests are the only changes.
+
+Command:
+
+```text
+PYTHONHASHSEED=0 TZ=UTC OMP_NUM_THREADS=1 /private/tmp/zotwatch-e0/bin/python -m pytest -q \
+  tests/test_runtime_config_e5.py tests/test_runtime_preflight_e5.py tests/test_runtime_cli_e5a.py
+```
+
+Expected result: pytest exits 2 during collection with two `ModuleNotFoundError: No module named 'zotwatch.runtime'` errors. This proves the E4 production tree has neither a Basic v2 effective-runtime adapter nor runtime preflight; the public CLI still defers all v2 execution.
+
+No E0 fixture/golden was changed.

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,6 +27,9 @@ PYTHONHASHSEED=0 TZ=UTC OMP_NUM_THREADS=1 /tmp/zotwatch-e0-venv/bin/python -m py
 | [test_zotero_sync_e3.py](test_zotero_sync_e3.py) | E3 revision state machine、trash/restore、分页失败、远端漂移、坏记录、full 对账、SQLite 原子提交与 stats 兼容 |
 | [test_computational_state_e4.py](test_computational_state_e4.py) | E4 profile/watch consistency、reuse/invalidation、library identity、模型隔离与 official run lease ownership |
 | [test_state_manifest_e4.py](test_state_manifest_e4.py) | E4 manifest/fingerprint、atomic generation publication、corruption/revision drift/interruption recovery |
+| [test_runtime_config_e5.py](test_runtime_config_e5.py) | E5A Basic v2 effective settings、engine-owned public connection、legacy runtime isolation |
+| [test_runtime_preflight_e5.py](test_runtime_preflight_e5.py) | E5A output/provider capability、credential presence 与 explicit Zotero verification |
+| [test_runtime_cli_e5a.py](test_runtime_cli_e5a.py) | E5A v2 dispatch、side-effect-free rejection、legacy-only option boundary |
 | [test_candidates.py](test_candidates.py) | 冻结 public v1 分页/映射，来源路由、12 小时 cache、故障回退与 Crossref 补抓 |
 | [test_profile_ranking_outputs.py](test_profile_ranking_outputs.py) | profile、真实 FAISS 保存/读取/检索、排名分项及稳定 tie、labels、recency 边界、SJR、RSS/HTML 完整 golden |
 | [test_pipeline_http.py](test_pipeline_http.py) | CLI profile → watch 的真实本地链路、HTTP 重试/错误、离线防护自检 |

--- a/tests/installed_probe.py
+++ b/tests/installed_probe.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import socket
 import sys
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 import numpy as np
 import requests
@@ -95,10 +96,52 @@ with journal_metrics_path("bundled", workspace) as bundled:
                                 metrics_path=bundled).journal_metrics
 pointer = json.loads((state / "computational/current.json").read_text())
 generation = state / "computational/generations" / pointer["generation_id"]
+
+# E5A: an installed Basic v2 workspace uses the same E3/E4/ranking/writer pipeline.
+v2_workspace = workspace.parent / (workspace.name + "-v2")
+v2_workspace.mkdir()
+(v2_workspace / "zotwatch.yaml").write_text("""schema_version: 2
+zotero:
+  library_type: user
+candidates:
+  provider: public-api-v1
+  sources: [crossref, arxiv, biorxiv]
+  window_days: 7
+ranking:
+  policy: legacy-v1
+  top_n: 3
+  max_preprint_ratio: 0.3
+embedding:
+  provider: local
+  model: sentence-transformers/all-MiniLM-L6-v2
+ai:
+  services: {}
+  features:
+    rerank: {enabled: false}
+    summary: {enabled: false}
+outputs:
+  formats: [rss, html]
+  publish: false
+""")
+ingest_zotero_api.ZoteroIngestor.run = lambda *a, **kw: SimpleNamespace(
+    fetched=0, updated=0, removed=0
+)
+v2_reports = workspace.parent / (workspace.name + "-v2-reports")
+v2_common = [
+    "--workspace", str(v2_workspace),
+    "--state-dir", str(state),
+    "--reports-dir", str(v2_reports),
+]
+assert public_main(["profile", *v2_common]) == 0
+assert public_main(["watch", *v2_common]) == 0
+assert (v2_reports / "feed.xml").read_bytes() == (reports / "feed.xml").read_bytes()
+assert (v2_reports / "report-20260114.html").is_file()
 print(json.dumps({
     "cli_module": cli.__file__,
     "state": str(state),
     "reports": str(reports),
     "profile": str(generation / "profile.json"),
     "manifest": str(generation / "state-manifest.json"),
+    "v2_feed": str(v2_reports / "feed.xml"),
+    "v2_report": str(v2_reports / "report-20260114.html"),
 }))

--- a/tests/test_config_installation.py
+++ b/tests/test_config_installation.py
@@ -33,6 +33,8 @@ def test_wheel_and_sdist_include_e2_engine_resources():
         names = set(wheel.namelist())
         assert "zotwatch/config/loader.py" in names
         assert "zotwatch/providers/registry.py" in names
+        assert "zotwatch/runtime/config.py" in names
+        assert "zotwatch/runtime/preflight.py" in names
     with tarfile.open(next(dist.glob("*.tar.gz"))) as archive:
         names = archive.getnames()
         assert any(name.endswith("zotwatch/resources/config-v2.schema.json") for name in names)
@@ -51,7 +53,7 @@ def test_installed_validate_works_outside_checkout(kind, fixture, tmp_path):
 
 
 @pytest.mark.parametrize("kind", ["WHEEL", "EDITABLE"])
-def test_installed_validate_rejects_secret_fields_and_deferred_execution(kind, tmp_path):
+def test_installed_rejects_secret_fields_and_unavailable_json(kind, tmp_path):
     python = configured(f"E1_{kind}_PYTHON")
     invalid = _v2_workspace(tmp_path, "invalid-secret.yaml")
     result = run(
@@ -67,5 +69,5 @@ def test_installed_validate_rejects_secret_fields_and_deferred_execution(kind, t
     result = run(
         [python.parent / "zotwatch", "watch", "--workspace", valid], valid, success=False
     )
-    assert result.returncode == 2
-    assert "CONFIG_V2_EXECUTION_DEFERRED" in result.stderr
+    assert result.returncode == 3
+    assert "OUTPUT_FORMAT_UNAVAILABLE" in result.stderr

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -113,5 +113,7 @@ def test_installed_pipeline_matches_e0_goldens(kind, entry, workspace):
     assert (reports / "full.xml").read_bytes() == (GOLDENS / "ranked.xml").read_bytes()
     assert (reports / "full.html").read_bytes() == (GOLDENS / "ranked.html").read_bytes()
     assert (reports / "report-20260114.html").exists()
+    assert Path(metadata["v2_feed"]).is_file()
+    assert Path(metadata["v2_report"]).is_file()
     assert before == {str(p): hashlib.sha256(p.read_bytes()).hexdigest() for p in package.rglob("*.py")}
     assert not any(p.suffix in {".sqlite", ".index", ".csv"} for p in package.rglob("*"))

--- a/tests/test_legacy_adapter.py
+++ b/tests/test_legacy_adapter.py
@@ -77,12 +77,12 @@ def test_validation_cli_is_offline_and_does_not_claim_ai_runtime(tmp_path, capsy
     assert "openrouter" not in output.out
 
 
-def test_public_cli_rejects_v2_execution_and_mixed_modes(tmp_path, workspace, capsys):
+def test_public_cli_gates_e5a_json_and_rejects_mixed_modes(tmp_path, workspace, capsys):
     v2_workspace = tmp_path / "v2-only"
     v2_workspace.mkdir()
     write_config(v2_workspace / "zotwatch.yaml", minimal_config())
-    assert public_cli.main(["watch", "--workspace", str(v2_workspace)]) == 2
-    assert "CONFIG_V2_EXECUTION_DEFERRED" in capsys.readouterr().err
+    assert public_cli.main(["watch", "--workspace", str(v2_workspace)]) == 3
+    assert "OUTPUT_FORMAT_UNAVAILABLE" in capsys.readouterr().err
 
     write_config(workspace / "zotwatch.yaml", minimal_config())
     assert public_cli.main(["profile", "--workspace", str(workspace)]) == 2

--- a/tests/test_runtime_cli_e5a.py
+++ b/tests/test_runtime_cli_e5a.py
@@ -1,0 +1,80 @@
+from copy import deepcopy
+
+import yaml
+
+from src import cli as legacy_cli
+from zotwatch import cli
+
+from .test_config_v2 import minimal_config
+
+
+def write_config(workspace, formats=("rss", "html"), *, ai=None):
+    data = deepcopy(minimal_config())
+    data["outputs"]["formats"] = list(formats)
+    if ai is not None:
+        data["ai"] = ai
+    (workspace / "zotwatch.yaml").write_text(
+        yaml.safe_dump(data, sort_keys=False), encoding="utf-8"
+    )
+
+
+def credentials(monkeypatch):
+    monkeypatch.setenv("ZOTERO_USER_ID", "12345")
+    monkeypatch.setenv("ZOTERO_API_KEY", "synthetic-zotero-key")
+
+
+def test_v2_watch_dispatches_existing_pipeline_with_config_values(
+    workspace, monkeypatch
+):
+    write_config(workspace)
+    credentials(monkeypatch)
+    calls = []
+    monkeypatch.setattr(
+        legacy_cli,
+        "run_watch",
+        lambda base, settings, storage, **kwargs: calls.append((base, settings, kwargs)),
+    )
+    assert cli.main(["watch", "--workspace", str(workspace)]) == 0
+    assert len(calls) == 1
+    base, settings, kwargs = calls[0]
+    assert base == workspace
+    assert settings.sources.public_api.enabled
+    assert kwargs["rss"] is True
+    assert kwargs["report"] is True
+    assert kwargs["top"] == 20
+    assert kwargs["push"] is False
+    assert kwargs["journal_metrics"] == "bundled"
+
+
+def test_json_and_ai_fail_before_pipeline_side_effects(workspace, monkeypatch, capsys):
+    credentials(monkeypatch)
+    called = []
+    monkeypatch.setattr(legacy_cli, "run_watch", lambda *args, **kwargs: called.append(1))
+
+    write_config(workspace, formats=("json",))
+    assert cli.main(["watch", "--workspace", str(workspace)]) == 3
+    assert "OUTPUT_FORMAT_UNAVAILABLE" in capsys.readouterr().err
+    assert called == []
+
+    ai = {
+        "services": {"s": {"provider": "openrouter", "model": "some-model"}},
+        "features": {
+            "rerank": {"enabled": False},
+            "summary": {"enabled": True, "service": "s"},
+        },
+    }
+    write_config(workspace, formats=("rss",), ai=ai)
+    assert cli.main(["watch", "--workspace", str(workspace)]) == 3
+    assert "CAPABILITY_UNAVAILABLE" in capsys.readouterr().err
+    assert called == []
+
+
+def test_v2_rejects_legacy_run_overlay_before_pipeline(workspace, monkeypatch, capsys):
+    write_config(workspace, formats=("rss",))
+    credentials(monkeypatch)
+    called = []
+    monkeypatch.setattr(legacy_cli, "run_watch", lambda *args, **kwargs: called.append(1))
+    assert cli.main(["watch", "--workspace", str(workspace), "--top", "5"]) == 2
+    assert "CONFIG_OPTION_UNSUPPORTED" in capsys.readouterr().err
+    assert called == []
+

--- a/tests/test_runtime_cli_e5a.py
+++ b/tests/test_runtime_cli_e5a.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import shutil
 
 import yaml
 
@@ -9,6 +10,8 @@ from .test_config_v2 import minimal_config
 
 
 def write_config(workspace, formats=("rss", "html"), *, ai=None):
+    if (workspace / "config").exists():
+        shutil.rmtree(workspace / "config")
     data = deepcopy(minimal_config())
     data["outputs"]["formats"] = list(formats)
     if ai is not None:
@@ -77,4 +80,3 @@ def test_v2_rejects_legacy_run_overlay_before_pipeline(workspace, monkeypatch, c
     assert cli.main(["watch", "--workspace", str(workspace), "--top", "5"]) == 2
     assert "CONFIG_OPTION_UNSUPPORTED" in capsys.readouterr().err
     assert called == []
-

--- a/tests/test_runtime_cli_e5a.py
+++ b/tests/test_runtime_cli_e5a.py
@@ -1,11 +1,16 @@
 from copy import deepcopy
 import shutil
+from types import SimpleNamespace
 
 import yaml
 
-from src import cli as legacy_cli
+from src import build_profile, cli as legacy_cli, fetch_new, ingest_zotero_api, score_rank
+from src.computational_state import pseudonymous_library_identity
+from src.models import ZoteroItem
+from src.storage import ProfileStorage
 from zotwatch import cli
 
+from .helpers import FIXTURES, FixedVectors, read_json
 from .test_config_v2 import minimal_config
 
 
@@ -80,3 +85,65 @@ def test_v2_rejects_legacy_run_overlay_before_pipeline(workspace, monkeypatch, c
     assert cli.main(["watch", "--workspace", str(workspace), "--top", "5"]) == 2
     assert "CONFIG_OPTION_UNSUPPORTED" in capsys.readouterr().err
     assert called == []
+
+
+def test_legacy_and_basic_v2_share_ranking_and_rss_html_content(
+    workspace, candidates, monkeypatch
+):
+    v2_workspace = workspace / "v2-workspace"
+    v2_workspace.mkdir()
+    write_config(v2_workspace)
+    identity = pseudonymous_library_identity("user", "123456")
+    legacy_state = workspace / "legacy-state"
+    v2_state = workspace / "v2-state"
+    for state in (legacy_state, v2_state):
+        storage = ProfileStorage(state / "profile.sqlite")
+        storage.initialize()
+        for row in read_json(FIXTURES / "zotero.json"):
+            item = ZoteroItem.from_zotero_api(row)
+            storage.upsert_item(item, f"hash-{item.key}")
+        storage.set_library_identity_sha256(identity)
+        storage.set_last_modified_version(10)
+        storage.close()
+
+    monkeypatch.setattr(
+        ingest_zotero_api.ZoteroIngestor,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(fetched=0, updated=0, removed=0),
+    )
+    monkeypatch.setattr(build_profile, "TextVectorizer", FixedVectors)
+    monkeypatch.setattr(score_rank, "TextVectorizer", FixedVectors)
+    monkeypatch.setattr(fetch_new.CandidateFetcher, "fetch_all", lambda self: candidates)
+    captures = []
+    original_rank = score_rank.WorkRanker.rank
+
+    def capture(self, values):
+        result = original_rank(self, values)
+        captures.append([item.model_dump(mode="json") for item in result])
+        return result
+
+    monkeypatch.setattr(score_rank.WorkRanker, "rank", capture)
+    legacy_reports = workspace / "legacy-reports"
+    v2_reports = workspace / "v2-reports"
+
+    legacy_cli.main([
+        "profile", "--workspace", str(workspace), "--state-dir", str(legacy_state)
+    ])
+    legacy_cli.main([
+        "watch", "--workspace", str(workspace), "--state-dir", str(legacy_state),
+        "--reports-dir", str(legacy_reports), "--rss", "--report", "--top", "20",
+        "--journal-metrics", "bundled",
+    ])
+    assert cli.main([
+        "profile", "--workspace", str(v2_workspace), "--state-dir", str(v2_state)
+    ]) == 0
+    assert cli.main([
+        "watch", "--workspace", str(v2_workspace), "--state-dir", str(v2_state),
+        "--reports-dir", str(v2_reports),
+    ]) == 0
+
+    assert captures[0] == captures[1]
+    assert (legacy_reports / "feed.xml").read_bytes() == (v2_reports / "feed.xml").read_bytes()
+    assert (legacy_reports / "report-20260114.html").read_bytes() == (
+        v2_reports / "report-20260114.html"
+    ).read_bytes()

--- a/tests/test_runtime_config_e5.py
+++ b/tests/test_runtime_config_e5.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import shutil
 
 import yaml
 
@@ -9,6 +10,7 @@ from .test_config_v2 import minimal_config
 
 
 def write_v2(workspace, *, formats=("rss", "html")):
+    shutil.rmtree(workspace / "config")
     data = deepcopy(minimal_config())
     data["outputs"]["formats"] = list(formats)
     (workspace / "zotwatch.yaml").write_text(
@@ -55,4 +57,3 @@ def test_legacy_runtime_uses_original_settings_not_projection(workspace, setting
     assert effective.source is ConfigSource.LEGACY
     assert effective.settings.model_dump() == settings.model_dump()
     assert effective.config_schema_version is None
-

--- a/tests/test_runtime_config_e5.py
+++ b/tests/test_runtime_config_e5.py
@@ -1,0 +1,58 @@
+from copy import deepcopy
+
+import yaml
+
+from zotwatch.config import ConfigSource
+from zotwatch.runtime.config import load_effective_runtime
+
+from .test_config_v2 import minimal_config
+
+
+def write_v2(workspace, *, formats=("rss", "html")):
+    data = deepcopy(minimal_config())
+    data["outputs"]["formats"] = list(formats)
+    (workspace / "zotwatch.yaml").write_text(
+        yaml.safe_dump(data, sort_keys=False), encoding="utf-8"
+    )
+    return data
+
+
+def test_basic_v2_maps_to_existing_runtime_without_user_public_key(
+    workspace, monkeypatch
+):
+    write_v2(workspace)
+    monkeypatch.setenv("ZOTERO_USER_ID", "12345")
+    monkeypatch.setenv("ZOTERO_API_KEY", "synthetic-zotero-key")
+
+    effective = load_effective_runtime(workspace)
+
+    assert effective.source is ConfigSource.V2
+    assert effective.config_schema_version == 2
+    assert effective.top_n == 20
+    assert effective.max_preprint_ratio == 0.3
+    assert effective.output_formats == ("rss", "html")
+    assert effective.journal_metrics == "bundled"
+    assert effective.settings.zotero.api.user_id == "12345"
+    assert effective.settings.sources.window_days == 7
+    assert effective.settings.sources.public_api.enabled
+    assert effective.settings.sources.public_api.publishable_key
+    assert effective.settings.scoring.weights.model_dump() == {
+        "similarity": 0.45,
+        "recency": 0.15,
+        "citations": 0.15,
+        "altmetric": 0.10,
+        "journal_quality": 0.04,
+        "author_bonus": 0.02,
+        "venue_bonus": 0.04,
+    }
+    rendered = repr(effective)
+    assert "synthetic-zotero-key" not in rendered
+    assert "sb_publishable" not in rendered
+
+
+def test_legacy_runtime_uses_original_settings_not_projection(workspace, settings):
+    effective = load_effective_runtime(workspace)
+    assert effective.source is ConfigSource.LEGACY
+    assert effective.settings.model_dump() == settings.model_dump()
+    assert effective.config_schema_version is None
+

--- a/tests/test_runtime_preflight_e5.py
+++ b/tests/test_runtime_preflight_e5.py
@@ -1,6 +1,8 @@
 from copy import deepcopy
+import shutil
 
 import yaml
+import requests
 
 from zotwatch.runtime.config import load_effective_runtime
 from zotwatch.runtime.preflight import preflight
@@ -9,6 +11,8 @@ from .test_config_v2 import minimal_config
 
 
 def write_config(workspace, data):
+    if (workspace / "config").exists():
+        shutil.rmtree(workspace / "config")
     (workspace / "zotwatch.yaml").write_text(
         yaml.safe_dump(data, sort_keys=False), encoding="utf-8"
     )
@@ -83,3 +87,51 @@ def test_missing_zotero_credentials_are_presence_not_verification(workspace, mon
     assert all(not item.configured for item in zotero)
     assert all(item.verification == "not_requested" for item in zotero)
 
+
+def test_live_zotero_verification_is_explicit_and_read_only(workspace, monkeypatch):
+    data = minimal_config()
+    data["outputs"]["formats"] = ["rss"]
+    write_config(workspace, data)
+    monkeypatch.setenv("ZOTERO_USER_ID", "12345")
+    monkeypatch.setenv("ZOTERO_API_KEY", "synthetic-zotero-key")
+    calls = []
+
+    class Response:
+        def raise_for_status(self):
+            return None
+
+    class Session:
+        def get(self, url, **kwargs):
+            calls.append((url, kwargs))
+            return Response()
+
+    report = preflight(
+        load_effective_runtime(workspace), verify_zotero=True, session=Session()
+    )
+    assert report.ready
+    assert calls[0][1]["params"] == {"limit": 1}
+    assert calls[0][1]["timeout"] == 15
+    assert all(
+        item.verification == "verified"
+        for item in report.requirements
+        if item.requirement_id.startswith("zotero")
+    )
+
+
+def test_live_zotero_failure_does_not_echo_remote_error(workspace, monkeypatch):
+    data = minimal_config()
+    data["outputs"]["formats"] = ["rss"]
+    write_config(workspace, data)
+    monkeypatch.setenv("ZOTERO_USER_ID", "12345")
+    monkeypatch.setenv("ZOTERO_API_KEY", "synthetic-zotero-key")
+
+    class Session:
+        def get(self, *args, **kwargs):
+            raise requests.ConnectionError("secret remote diagnostic")
+
+    report = preflight(
+        load_effective_runtime(workspace), verify_zotero=True, session=Session()
+    )
+    assert not report.ready
+    assert report.error_code == "CREDENTIAL_VERIFICATION_FAILED"
+    assert "secret remote diagnostic" not in report.model_dump_json()

--- a/tests/test_runtime_preflight_e5.py
+++ b/tests/test_runtime_preflight_e5.py
@@ -1,0 +1,85 @@
+from copy import deepcopy
+
+import yaml
+
+from zotwatch.runtime.config import load_effective_runtime
+from zotwatch.runtime.preflight import preflight
+
+from .test_config_v2 import minimal_config
+
+
+def write_config(workspace, data):
+    (workspace / "zotwatch.yaml").write_text(
+        yaml.safe_dump(data, sort_keys=False), encoding="utf-8"
+    )
+
+
+def test_basic_rss_html_needs_no_ai_or_public_pool_credential(workspace, monkeypatch):
+    data = minimal_config()
+    data["outputs"]["formats"] = ["rss", "html"]
+    write_config(workspace, data)
+    monkeypatch.setenv("ZOTERO_USER_ID", "12345")
+    monkeypatch.setenv("ZOTERO_API_KEY", "synthetic-zotero-key")
+
+    report = preflight(load_effective_runtime(workspace))
+
+    assert report.ready
+    assert report.error_code is None
+    assert {item.requirement_id for item in report.requirements} == {
+        "zotero.identity",
+        "zotero.read",
+        "public-candidates",
+    }
+    public = next(
+        item for item in report.requirements if item.requirement_id == "public-candidates"
+    )
+    assert public.user_credential_required is False
+    assert "API_KEY" not in report.model_dump_json()
+    assert "synthetic-zotero-key" not in report.model_dump_json()
+
+
+def test_e5a_json_is_explicitly_unavailable(workspace, monkeypatch):
+    write_config(workspace, minimal_config())
+    monkeypatch.setenv("ZOTERO_USER_ID", "12345")
+    monkeypatch.setenv("ZOTERO_API_KEY", "synthetic-zotero-key")
+    report = preflight(load_effective_runtime(workspace))
+    assert not report.ready
+    assert report.error_code == "OUTPUT_FORMAT_UNAVAILABLE"
+
+
+def test_registered_but_unimplemented_ai_is_not_executable(workspace, monkeypatch):
+    data = deepcopy(minimal_config())
+    data["outputs"]["formats"] = ["rss"]
+    data["ai"] = {
+        "services": {
+            "summary-service": {"provider": "openrouter", "model": "some-model"}
+        },
+        "features": {
+            "rerank": {"enabled": False},
+            "summary": {"enabled": True, "service": "summary-service"},
+        },
+    }
+    write_config(workspace, data)
+    monkeypatch.setenv("ZOTERO_USER_ID", "12345")
+    monkeypatch.setenv("ZOTERO_API_KEY", "synthetic-zotero-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "must-not-be-validated-or-printed")
+    report = preflight(load_effective_runtime(workspace))
+    assert not report.ready
+    assert report.error_code == "CAPABILITY_UNAVAILABLE"
+    assert "must-not-be-validated-or-printed" not in report.model_dump_json()
+    assert "OPENROUTER_API_KEY" not in report.model_dump_json()
+
+
+def test_missing_zotero_credentials_are_presence_not_verification(workspace, monkeypatch):
+    data = minimal_config()
+    data["outputs"]["formats"] = ["html"]
+    write_config(workspace, data)
+    monkeypatch.delenv("ZOTERO_USER_ID", raising=False)
+    monkeypatch.delenv("ZOTERO_API_KEY", raising=False)
+    report = preflight(load_effective_runtime(workspace))
+    assert not report.ready
+    assert report.error_code == "CREDENTIAL_MISSING"
+    zotero = [item for item in report.requirements if item.requirement_id.startswith("zotero")]
+    assert all(not item.configured for item in zotero)
+    assert all(item.verification == "not_requested" for item in zotero)
+

--- a/zotwatch/cli.py
+++ b/zotwatch/cli.py
@@ -1,4 +1,4 @@
-"""Public console entry point with an offline v2 configuration command."""
+"""Public console entry point for legacy and Basic v2 workspaces."""
 
 from __future__ import annotations
 
@@ -10,6 +10,32 @@ import sys
 def _validation_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="zotwatch config validate")
     parser.add_argument("--workspace", help="Workspace containing zotwatch.yaml or legacy config")
+    return parser
+
+
+def _preflight_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="zotwatch runtime preflight")
+    parser.add_argument("--workspace", help="Workspace containing ZotWatch configuration")
+    parser.add_argument("--json", action="store_true", help="Emit the redacted v1 report")
+    parser.add_argument("--verify-zotero", action="store_true", help="Verify Zotero explicitly")
+    return parser
+
+
+def _v2_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="zotwatch")
+    parser.add_argument("command", choices=["profile", "watch"])
+    parser.add_argument("--workspace")
+    parser.add_argument("--base-dir")
+    parser.add_argument("--state-dir")
+    parser.add_argument("--reports-dir")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--full", action="store_true")
+    parser.add_argument("--weekly", action="store_true")
+    parser.add_argument("--rss", action="store_true")
+    parser.add_argument("--report", action="store_true")
+    parser.add_argument("--top", type=int)
+    parser.add_argument("--push", action="store_true")
+    parser.add_argument("--journal-metrics")
     return parser
 
 
@@ -45,11 +71,103 @@ def _validate(argv: list[str]) -> int:
     return 0
 
 
+def _runtime_preflight(argv: list[str]) -> int:
+    from dotenv import load_dotenv
+    from zotwatch.runtime import load_effective_runtime, preflight
+
+    args = _preflight_parser().parse_args(argv)
+    workspace = Path(args.workspace).resolve() if args.workspace else Path.cwd().resolve()
+    load_dotenv(workspace / ".env")
+    report = preflight(
+        load_effective_runtime(workspace), verify_zotero=args.verify_zotero
+    )
+    if args.json:
+        print(report.model_dump_json())
+    elif report.ready:
+        print("Runtime preflight is ready.")
+    else:
+        print(f"Runtime preflight failed: {report.error_code}.", file=sys.stderr)
+    return 0 if report.ready else 3
+
+
+def _has_option(arguments: list[str], option: str) -> bool:
+    return option in arguments or any(value.startswith(f"{option}=") for value in arguments)
+
+
+def _run_v2(arguments: list[str]) -> int:
+    from dotenv import load_dotenv
+    from src import cli as engine_cli
+    from src.logging_utils import setup_logging
+    from src.storage import ProfileStorage
+    from zotwatch.paths import RuntimePaths
+    from zotwatch.runtime import load_effective_runtime, preflight
+
+    args = _v2_parser().parse_args(arguments)
+    paths = RuntimePaths.resolve(
+        workspace=args.workspace,
+        base_dir=args.base_dir,
+        state_dir=args.state_dir,
+        reports_dir=args.reports_dir,
+    )
+    load_dotenv(paths.workspace / ".env")
+    effective = load_effective_runtime(paths.workspace)
+    forbidden = ("--rss", "--report", "--top", "--push", "--journal-metrics")
+    if any(_has_option(arguments, option) for option in forbidden):
+        print(
+            "CONFIG_OPTION_UNSUPPORTED: Basic v2 runtime options come from zotwatch.yaml",
+            file=sys.stderr,
+        )
+        return 2
+    report = preflight(effective)
+    if not report.ready:
+        print(f"{report.error_code}: runtime preflight failed", file=sys.stderr)
+        return 3
+
+    setup_logging(verbose=args.verbose)
+    storage = ProfileStorage(paths.state / "profile.sqlite")
+    try:
+        if args.command == "profile":
+            engine_cli.run_profile(
+                paths.workspace,
+                effective.settings,
+                storage,
+                full=args.full or args.weekly,
+                state_dir=paths.state,
+            )
+        else:
+            engine_cli.run_watch(
+                paths.workspace,
+                effective.settings,
+                storage,
+                rss="rss" in effective.output_formats,
+                report="html" in effective.output_formats,
+                top=effective.top_n,
+                push=False,
+                state_dir=paths.state,
+                reports_dir=paths.reports,
+                journal_metrics=effective.journal_metrics,
+            )
+    finally:
+        storage.close()
+    return 0
+
+
 def main(argv=None):
     arguments = list(sys.argv[1:] if argv is None else argv)
     if arguments[:2] == ["config", "validate"]:
         try:
             return _validate(arguments[2:])
+        except Exception as exc:
+            from zotwatch.config import ConfigError
+
+            if not isinstance(exc, ConfigError):
+                raise
+            print(str(exc), file=sys.stderr)
+            return 2
+
+    if arguments[:2] == ["runtime", "preflight"]:
+        try:
+            return _runtime_preflight(arguments[2:])
         except Exception as exc:
             from zotwatch.config import ConfigError
 
@@ -67,12 +185,11 @@ def main(argv=None):
             print(str(exc), file=sys.stderr)
             return 2
         if source is ConfigSource.V2:
-            error = ConfigError(
-                "CONFIG_V2_EXECUTION_DEFERRED",
-                "E2 validates zotwatch.yaml but does not connect it to recommendation execution",
-            )
-            print(str(error), file=sys.stderr)
-            return 2
+            try:
+                return _run_v2(arguments)
+            except ValueError as exc:
+                print(f"CONFIG_INVALID: {exc}", file=sys.stderr)
+                return 2
 
     from src.cli import main as legacy_main
 

--- a/zotwatch/config/legacy.py
+++ b/zotwatch/config/legacy.py
@@ -9,7 +9,7 @@ from .models import ZotWatchConfigV2
 from .semantic import resolve_feature_routes
 
 
-_LEGACY_SCORING_POLICY = {
+LEGACY_V1_SCORING_POLICY = {
     "weights": {
         "similarity": 0.45,
         "recency": 0.15,
@@ -90,7 +90,7 @@ def project_legacy_to_v2(settings: Settings, *, top_n: int = 20) -> LegacyMappin
         issues.append(
             _issue("/sources/altmetric/enabled", "LEGACY_MAPPING_LOSS", "Altmetric is legacy-only")
         )
-    if settings.scoring.model_dump() != _LEGACY_SCORING_POLICY:
+    if settings.scoring.model_dump() != LEGACY_V1_SCORING_POLICY:
         issues.append(
             _issue("/scoring", "LEGACY_MAPPING_LOSS", "custom legacy scoring cannot be projected losslessly")
         )
@@ -163,5 +163,6 @@ __all__ = [
     "LegacyLoadResult",
     "LegacyMappingIssue",
     "LegacyMappingReport",
+    "LEGACY_V1_SCORING_POLICY",
     "project_legacy_to_v2",
 ]

--- a/zotwatch/runtime/__init__.py
+++ b/zotwatch/runtime/__init__.py
@@ -1,0 +1,5 @@
+"""Effective runtime configuration and preflight for installed ZotWatch."""
+
+from .config import EffectiveRuntimeConfig, load_effective_runtime
+
+__all__ = ["EffectiveRuntimeConfig", "load_effective_runtime"]

--- a/zotwatch/runtime/__init__.py
+++ b/zotwatch/runtime/__init__.py
@@ -1,5 +1,6 @@
 """Effective runtime configuration and preflight for installed ZotWatch."""
 
 from .config import EffectiveRuntimeConfig, load_effective_runtime
+from .preflight import PreflightReport, preflight
 
-__all__ = ["EffectiveRuntimeConfig", "load_effective_runtime"]
+__all__ = ["EffectiveRuntimeConfig", "PreflightReport", "load_effective_runtime", "preflight"]

--- a/zotwatch/runtime/config.py
+++ b/zotwatch/runtime/config.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from hashlib import sha256
+import json
+import os
+from pathlib import Path
+
+from src.settings import (
+    AltmetricConfig,
+    ArxivConfig,
+    BioRxivConfig,
+    CrossRefConfig,
+    MedRxivConfig,
+    OpenAlexConfig,
+    PublicCandidatesApiConfig,
+    ScoringConfig,
+    Settings,
+    SourcesConfig,
+    ZoteroApiConfig,
+    ZoteroConfig,
+)
+from zotwatch.config import ConfigSource, ResolvedFeatureRoute, load_workspace_config
+from zotwatch.config.legacy import LEGACY_V1_SCORING_POLICY
+
+
+_ZOTERO_ID_SLOT = "ZOTERO_USER_ID"
+_ZOTERO_KEY_SLOT = "ZOTERO_API_KEY"
+
+
+@dataclass(frozen=True)
+class EffectiveRuntimeConfig:
+    source: ConfigSource
+    config_schema_version: int | None
+    config_fingerprint_sha256: str
+    settings: Settings = field(repr=False)
+    top_n: int = 50
+    max_preprint_ratio: float = 0.3
+    output_formats: tuple[str, ...] = ()
+    publish_requested: bool = False
+    journal_metrics: str = "legacy"
+    feature_routes: tuple[ResolvedFeatureRoute, ...] = field(default=(), repr=False)
+
+
+def _fingerprint(payload: dict) -> str:
+    data = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+    return sha256(data).hexdigest()
+
+
+def _v2_settings(loaded) -> Settings:
+    config = loaded.config
+    assert config is not None
+    connection = loaded.public_candidates
+    assert connection is not None
+    sources = set(config.candidates.sources)
+    return Settings(
+        zotero=ZoteroConfig(
+            mode="api",
+            api=ZoteroApiConfig(
+                user_id=os.getenv(_ZOTERO_ID_SLOT, ""),
+                api_key_env=_ZOTERO_KEY_SLOT,
+            ),
+        ),
+        sources=SourcesConfig(
+            window_days=config.candidates.window_days,
+            public_api=PublicCandidatesApiConfig(
+                enabled=True,
+                base_url=connection.base_url,
+                publishable_key=connection.publishable_key,
+                page_size=connection.page_size,
+                timeout_seconds=connection.timeout_seconds,
+            ),
+            openalex=OpenAlexConfig(enabled="openalex" in sources),
+            crossref=CrossRefConfig(enabled="crossref" in sources),
+            arxiv=ArxivConfig(enabled="arxiv" in sources),
+            biorxiv=BioRxivConfig(
+                enabled="biorxiv" in sources,
+                from_days_ago=config.candidates.window_days,
+            ),
+            medrxiv=MedRxivConfig(
+                enabled="medrxiv" in sources,
+                from_days_ago=config.candidates.window_days,
+            ),
+            altmetric=AltmetricConfig(enabled=False),
+        ),
+        scoring=ScoringConfig.model_validate(LEGACY_V1_SCORING_POLICY),
+    )
+
+
+def load_effective_runtime(workspace: Path | str) -> EffectiveRuntimeConfig:
+    loaded = load_workspace_config(Path(workspace))
+    if loaded.source is ConfigSource.LEGACY:
+        assert loaded.legacy_settings is not None
+        return EffectiveRuntimeConfig(
+            source=loaded.source,
+            config_schema_version=None,
+            config_fingerprint_sha256=_fingerprint({"source": "legacy"}),
+            settings=loaded.legacy_settings,
+        )
+
+    config = loaded.config
+    assert config is not None
+    safe_semantics = {
+        "schema_version": config.schema_version,
+        "zotero": {"library_type": config.zotero.library_type},
+        "candidates": config.candidates.model_dump(mode="json"),
+        "ranking": config.ranking.model_dump(mode="json"),
+        "embedding": config.embedding.model_dump(mode="json"),
+        "ai_features": {
+            route.feature: {
+                "provider": route.provider_id,
+                "protocol": route.protocol_id,
+                "runtime": route.adapter_status.value,
+            }
+            for route in loaded.routes
+        },
+        "outputs": config.outputs.model_dump(mode="json"),
+    }
+    return EffectiveRuntimeConfig(
+        source=loaded.source,
+        config_schema_version=config.schema_version,
+        config_fingerprint_sha256=_fingerprint(safe_semantics),
+        settings=_v2_settings(loaded),
+        top_n=config.ranking.top_n,
+        max_preprint_ratio=config.ranking.max_preprint_ratio,
+        output_formats=tuple(config.outputs.formats),
+        publish_requested=config.outputs.publish,
+        journal_metrics="bundled",
+        feature_routes=loaded.routes,
+    )
+
+
+__all__ = ["EffectiveRuntimeConfig", "load_effective_runtime"]

--- a/zotwatch/runtime/preflight.py
+++ b/zotwatch/runtime/preflight.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+import requests
+
+from zotwatch.config import ConfigSource
+from zotwatch.providers import AdapterStatus, credential_for_custom_connection, credential_for_provider
+
+from .config import EffectiveRuntimeConfig
+
+
+class _Model(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class RequirementStatus(_Model):
+    requirement_id: str
+    configured: bool
+    runtime_supported: bool
+    verification: Literal["not_requested", "verified", "failed", "unsupported"]
+    user_credential_required: bool = True
+
+
+class PreflightReport(_Model):
+    schema_version: Literal[1] = 1
+    ready: bool
+    error_code: str | None
+    requirements: tuple[RequirementStatus, ...]
+
+
+def _slot_for_route(route) -> str | None:
+    if route.provider_id == "custom":
+        connection_id = route.credential_internal_id.removeprefix("custom:")
+        credential = credential_for_custom_connection(connection_id)
+    else:
+        credential = credential_for_provider(route.provider_id)
+    return credential.workflow_secret_name if credential else None
+
+
+def preflight(
+    config: EffectiveRuntimeConfig,
+    *,
+    verify_zotero: bool = False,
+    session: requests.Session | None = None,
+) -> PreflightReport:
+    settings = config.settings
+    identity_present = bool(settings.zotero.api.user_id) and not settings.zotero.api.user_id.startswith("${")
+    key_slot = settings.zotero.api.api_key_env
+    key_present = bool(os.getenv(key_slot))
+    verification: Literal["not_requested", "verified", "failed", "unsupported"] = "not_requested"
+
+    error_code = None
+    if "json" in config.output_formats:
+        error_code = "OUTPUT_FORMAT_UNAVAILABLE"
+    elif any(route.adapter_status is not AdapterStatus.IMPLEMENTED for route in config.feature_routes):
+        error_code = "CAPABILITY_UNAVAILABLE"
+    elif not identity_present or not key_present:
+        error_code = "CREDENTIAL_MISSING"
+
+    if verify_zotero and error_code is None:
+        client = session or requests.Session()
+        try:
+            response = client.get(
+                f"https://api.zotero.org/users/{settings.zotero.api.user_id}/items",
+                params={"limit": 1},
+                headers={"Zotero-API-Key": os.environ[key_slot]},
+                timeout=15,
+            )
+            response.raise_for_status()
+            verification = "verified"
+        except requests.RequestException:
+            verification = "failed"
+            error_code = "CREDENTIAL_VERIFICATION_FAILED"
+
+    requirements = [
+        RequirementStatus(
+            requirement_id="zotero.identity",
+            configured=identity_present,
+            runtime_supported=True,
+            verification=verification,
+        ),
+        RequirementStatus(
+            requirement_id="zotero.read",
+            configured=key_present,
+            runtime_supported=True,
+            verification=verification,
+        ),
+    ]
+    if config.settings.sources.public_api.enabled:
+        requirements.append(
+            RequirementStatus(
+                requirement_id="public-candidates",
+                configured=True,
+                runtime_supported=True,
+                verification="not_requested",
+                user_credential_required=False,
+            )
+        )
+    for route in config.feature_routes:
+        slot = _slot_for_route(route)
+        requirements.append(
+            RequirementStatus(
+                requirement_id=f"feature.{route.feature}",
+                configured=bool(slot and os.getenv(slot)),
+                runtime_supported=route.adapter_status is AdapterStatus.IMPLEMENTED,
+                verification="unsupported"
+                if route.adapter_status is not AdapterStatus.IMPLEMENTED
+                else "not_requested",
+            )
+        )
+    return PreflightReport(
+        ready=error_code is None,
+        error_code=error_code,
+        requirements=tuple(requirements),
+    )
+
+
+__all__ = ["PreflightReport", "RequirementStatus", "preflight"]


### PR DESCRIPTION
Basic v2 configurations now map to one effective runtime model and execute through the existing E3 sync, E4 state, candidate, dedupe, ranking, RSS, and HTML pipeline. Preflight resolves fixed credential requirements and runtime capabilities before side effects; JSON remains explicitly unavailable until E5B.

The legacy entry point and behavior remain intact. Equivalent default legacy and Basic v2 runs produce identical ranked objects and RSS/HTML bytes. No sync, computational-state, candidate, scoring, filter, output-writer, AI, harvester, or public API behavior was changed.

Validation:
- local source suite: 189 passed, 16 skipped
- local forced wheel/editable suite: 205 passed
- wheel and editable `pip check`: clean
- E0 fixtures/goldens unchanged
- remote push E0 characterization: passed (run 34576908068)
- remote push packaging/config: passed (run 34576908078)
- PR checks run against the same head SHA