### PR TITLE
E5B: add versioned results and safe output publication

### DIFF
--- a/.github/workflows/characterization.yml
+++ b/.github/workflows/characterization.yml
@@ -3,7 +3,7 @@ name: E0 characterization
 on:
   pull_request:
   push:
-    branches: [main, codex/dev, codex/v2, codex/v2-e0, codex/v2-e2, codex/v2-e4, codex/v2-e5a]
+    branches: [main, codex/dev, codex/v2, codex/v2-e0, codex/v2-e2, codex/v2-e4, codex/v2-e5a, codex/v2-e5b]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -3,7 +3,7 @@ name: E1 packaging and E2 config
 on:
   pull_request:
   push:
-    branches: [codex/v2, codex/v2-e1, codex/v2-e2, codex/v2-e4, codex/v2-e5a]
+    branches: [codex/v2, codex/v2-e1, codex/v2-e2, codex/v2-e4, codex/v2-e5a, codex/v2-e5b]
   workflow_dispatch:
 
 permissions:

--- a/E5_IMPLEMENTATION_PLAN.md
+++ b/E5_IMPLEMENTATION_PLAN.md
@@ -2,7 +2,7 @@
 
 日期：2026-09-11
 
-状态：**已批准；E5A implementation complete，等待远端封板；E5B 尚未开始。**
+状态：**已批准；E5A 已封板；E5B implementation complete，等待远端封板。**
 
 起点：`v2-e4-baseline` / `5afdaa603ec5e9978ea871505c6233c33e23b7a3`。
 

--- a/docs/E5_RUNTIME_RESULTS.md
+++ b/docs/E5_RUNTIME_RESULTS.md
@@ -1,0 +1,37 @@
+# E5 — Runtime and Result Contracts
+
+E5A maps Basic v2 configuration into the existing E3/E4 recommendation
+pipeline. E5B adds versioned recommendation, private run-manifest, and machine
+run-result contracts around that same computation.
+
+Recommendation JSON v1 preserves the explicit public candidate identity and
+preprint metadata that the source supplied. Its score breakdown contains the
+seven additive legacy components: similarity, recency, citations, altmetric,
+journal quality, author bonus, and venue bonus. Every component reports its raw
+value, weighted contribution, and whether its input was available. The
+contributions reproduce the existing score without changing the formula,
+weights, thresholds, or ordering.
+
+Each v2 watch renders all requested output formats into a run-scoped staging
+directory. After validation, the directory becomes an immutable generation and
+`latest-success.json` atomically selects it. The pointer's finalized artifact
+whitelist records generation-relative paths, SHA-256, byte size, media type, and
+publishability. Stable files such as `feed.xml`, `report.html`, and
+`recommendations.json` are compatibility aliases; downstream P2 code must use
+the immutable whitelist returned by `RunResult`.
+
+Private manifests live under the state root and contain only relative paths,
+stable stage IDs, closed symbolic errors, and opaque diagnostic IDs. They do not
+serialize credential values or names, raw Zotero user IDs/items, Custom base
+URLs, absolute paths, exception strings, or tracebacks. `--machine-result`
+emits one closed JSON object and uses exit categories 0, 2, 3, 4, or 5.
+
+Candidate acquisition now exposes an additive outcome API. The legacy
+`fetch_all()` list API remains available. Complete empty acquisition is a valid
+result; all configured sources failing without a usable cache is a failed run;
+partial or stale-cache acquisition is degraded. Strict v2 runs return exit 5
+and do not replace the successful output pointer.
+
+E5 does not add AI requests, change ranking, alter E3 synchronization or E4
+state semantics, implement artifact transport, or change the public candidate
+API. E0 fixtures and goldens remain unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ Repository = "https://github.com/Yorks0n/ZotWatch"
 zotwatch = "zotwatch.cli:main"
 
 [tool.setuptools]
-packages = ["src", "zotwatch", "zotwatch.config", "zotwatch.providers", "zotwatch.resources", "zotwatch.runtime"]
+packages = ["src", "zotwatch", "zotwatch.config", "zotwatch.providers", "zotwatch.resources", "zotwatch.runtime", "zotwatch.results"]
 include-package-data = false
 
 [tool.setuptools.package-data]

--- a/src/cli.py
+++ b/src/cli.py
@@ -34,6 +34,178 @@ from .settings import Settings, load_settings
 from .storage import ProfileStorage
 from .report_html import render_html
 
+
+def run_profile_recorded(
+    base_dir: Path,
+    settings: Settings,
+    storage: ProfileStorage,
+    *,
+    full: bool,
+    state_dir: Path,
+    recorder,
+):
+    state_root = Path(state_dir)
+    coordinator = StateCoordinator(state_root)
+    manager = StateManager(state_root, coordinator=coordinator)
+    vectorizer = build_profile_module.TextVectorizer()
+    with coordinator.acquire() as lease:
+        try:
+            recorder.start("zotero_sync")
+            ZoteroIngestor(storage, settings).run(
+                full=full, library_identity_sha256=_library_identity(settings), lease=lease
+            )
+            recorder.finish("zotero_sync")
+        except Exception:
+            recorder.fail("zotero_sync", "ZOTERO_SYNC_FAILED")
+            return recorder.finalize(status="failed", exit_code=4, error_code="ZOTERO_SYNC_FAILED")
+        try:
+            recorder.start("computational_state")
+            handle, _ = _ensure_computational_state(
+                base_dir, settings, storage, state_root=state_root, manager=manager,
+                vectorizer=vectorizer, lease=lease, force=full,
+            )
+            recorder.finish("computational_state")
+        except Exception:
+            recorder.fail("computational_state", "STATE_BUILD_FAILED")
+            return recorder.finalize(status="failed", exit_code=4, error_code="STATE_BUILD_FAILED")
+    return recorder.finalize(
+        status="succeeded", exit_code=0, state_generation_id=handle.generation_id
+    )
+
+
+def run_watch_recorded(
+    base_dir: Path,
+    settings: Settings,
+    storage: ProfileStorage,
+    *,
+    state_dir: Path,
+    reports_dir: Path,
+    output_formats: tuple[str, ...],
+    top: int,
+    max_preprint_ratio: float,
+    journal_metrics: str,
+    strict: bool,
+    recorder,
+):
+    from zotwatch.results.projector import project_recommendations
+    from zotwatch.results.publication import OutputPublisher, PublicationError
+
+    state_root = Path(state_dir)
+    coordinator = StateCoordinator(state_root)
+    manager = StateManager(state_root, coordinator=coordinator)
+    vectorizer = build_profile_module.TextVectorizer()
+    with coordinator.acquire() as lease:
+        try:
+            recorder.start("zotero_sync")
+            ZoteroIngestor(storage, settings).run(
+                full=False, library_identity_sha256=_library_identity(settings), lease=lease
+            )
+            recorder.finish("zotero_sync")
+        except Exception:
+            recorder.fail("zotero_sync", "ZOTERO_SYNC_FAILED")
+            return recorder.finalize(status="failed", exit_code=4, error_code="ZOTERO_SYNC_FAILED")
+        try:
+            recorder.start("computational_state")
+            state_handle, _ = _ensure_computational_state(
+                base_dir, settings, storage, state_root=state_root, manager=manager,
+                vectorizer=vectorizer, lease=lease, force=False,
+            )
+            recorder.finish("computational_state")
+        except Exception:
+            recorder.fail("computational_state", "STATE_BUILD_FAILED")
+            return recorder.finalize(status="failed", exit_code=4, error_code="STATE_BUILD_FAILED")
+        try:
+            recorder.start("candidate_fetch")
+            outcome = CandidateFetcher(
+                settings, base_dir, profile_summary=state_handle.profile, state_dir=state_root
+            ).fetch_with_outcome()
+            if outcome.status == "failed":
+                recorder.fail("candidate_fetch", "CANDIDATE_UNAVAILABLE")
+                return recorder.finalize(
+                    status="failed", exit_code=4, error_code="CANDIDATE_UNAVAILABLE",
+                    state_generation_id=state_handle.generation_id,
+                )
+            degraded = outcome.status == "degraded"
+            if degraded:
+                code = "CANDIDATE_STALE_CACHE" if outcome.used_cache else "CANDIDATE_PARTIAL"
+                recorder.degrade("candidate_fetch", code, count=len(outcome.candidates))
+            else:
+                recorder.finish("candidate_fetch", count=len(outcome.candidates))
+        except Exception:
+            recorder.fail("candidate_fetch", "CANDIDATE_UNAVAILABLE")
+            return recorder.finalize(
+                status="failed", exit_code=4, error_code="CANDIDATE_UNAVAILABLE",
+                state_generation_id=state_handle.generation_id,
+            )
+        try:
+            recorder.start("dedupe")
+            filtered = DedupeEngine(storage).filter(outcome.candidates)
+            recorder.finish("dedupe", count=len(filtered))
+        except Exception:
+            recorder.fail("dedupe", "DEDUPE_FAILED")
+            return recorder.finalize(status="failed", exit_code=4, error_code="DEDUPE_FAILED", state_generation_id=state_handle.generation_id)
+        try:
+            recorder.start("ranking")
+            with journal_metrics_path(journal_metrics, base_dir) as metrics_path:
+                options = {"state_dir": state_root, "state_handle": state_handle}
+                if metrics_path is not None:
+                    options["metrics_path"] = metrics_path
+                ranked = WorkRanker(base_dir, settings, vectorizer, **options).rank(filtered)
+            ranked = _filter_recent(ranked, days=7)
+            ranked = _limit_preprints(ranked, max_ratio=max_preprint_ratio)
+            if top and len(ranked) > top:
+                ranked = ranked[:top]
+            recorder.finish("ranking", count=len(ranked))
+        except Exception:
+            recorder.fail("ranking", "RANKING_FAILED")
+            return recorder.finalize(status="failed", exit_code=4, error_code="RANKING_FAILED", state_generation_id=state_handle.generation_id)
+
+    if degraded and strict:
+        return recorder.finalize(
+            status="degraded", exit_code=5, state_generation_id=state_handle.generation_id
+        )
+    recorder.start("output_render")
+    try:
+        recommendation = project_recommendations(
+            ranked, settings.scoring.weights, run_id=recorder.run_id,
+            generated_at=recorder.generated_at,
+        )
+    except Exception:
+        recorder.fail("output_render", "OUTPUT_CONTRACT_INVALID")
+        return recorder.finalize(
+            status="failed", exit_code=4, error_code="OUTPUT_CONTRACT_INVALID",
+            state_generation_id=state_handle.generation_id,
+        )
+    renderers = {}
+    if "json" in output_formats:
+        renderers["recommendations.json"] = lambda path: path.write_text(
+            recommendation.model_dump_json(indent=2) + "\n", encoding="utf-8"
+        )
+    if "rss" in output_formats:
+        renderers["feed.xml"] = lambda path: write_rss(ranked, path)
+    if "html" in output_formats:
+        renderers["report.html"] = lambda path: render_html(ranked, path)
+    recorder.finish("zotero_writeback")
+    try:
+        published = OutputPublisher(reports_dir).publish(recorder.run_id, renderers)
+        recorder.finish("output_render", count=len(published.artifacts))
+        recorder.start("output_publish")
+        recorder.finish("output_publish", count=len(published.artifacts))
+    except PublicationError as exc:
+        code = exc.code
+        stage = "output_publish" if code == "OUTPUT_PUBLISH_FAILED" else "output_render"
+        recorder.fail(stage, code)
+        return recorder.finalize(status="failed", exit_code=4, error_code=code, state_generation_id=state_handle.generation_id)
+    except Exception:
+        recorder.fail("output_publish", "OUTPUT_PUBLISH_FAILED")
+        return recorder.finalize(status="failed", exit_code=4, error_code="OUTPUT_PUBLISH_FAILED", state_generation_id=state_handle.generation_id)
+    return recorder.finalize(
+        status="degraded" if degraded else "succeeded", exit_code=0,
+        state_generation_id=state_handle.generation_id,
+        output_generation_id=published.generation_id,
+        artifacts=published.artifacts,
+    )
+
 def main(argv: Optional[list[str]] = None) -> None:
     parser = argparse.ArgumentParser(description="ZotWatcher CLI")
     parser.add_argument("command", choices=["profile", "watch"], help="Command to run")

--- a/src/fetch_new.py
+++ b/src/fetch_new.py
@@ -5,6 +5,7 @@ import json
 import html
 import re
 import time
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import List
@@ -20,6 +21,15 @@ from .utils import ensure_isoformat, iso_to_datetime, utc_now
 logger = logging.getLogger(__name__)
 ARXIV_REQUEST_DELAY_SECONDS = 3.1
 ARXIV_MAX_RESULTS = 50
+
+
+@dataclass(frozen=True)
+class CandidateFetchOutcome:
+    candidates: List[CandidateWork]
+    status: str
+    used_cache: bool
+    request_complete: bool
+    failed_sources: int = 0
 
 
 class CandidateFetcher:
@@ -43,6 +53,9 @@ class CandidateFetcher:
         self.top_venues = self._load_top_venues()
 
     def fetch_all(self) -> List[CandidateWork]:
+        return self.fetch_with_outcome().candidates
+
+    def fetch_with_outcome(self) -> CandidateFetchOutcome:
         stale_candidates: List[CandidateWork] | None = None
         cached = self._load_cache()
         if cached:
@@ -55,7 +68,7 @@ class CandidateFetcher:
                     fetched_at.isoformat(),
                     age.total_seconds() / 3600,
                 )
-                return candidates
+                return CandidateFetchOutcome(candidates, "succeeded", True, True)
             logger.info(
                 "Candidate cache is stale (age %.1f hours); refreshing",
                 age.total_seconds() / 3600,
@@ -123,11 +136,16 @@ class CandidateFetcher:
                 enabled_sources,
                 len(stale_candidates),
             )
-            return stale_candidates
+            return CandidateFetchOutcome(
+                stale_candidates, "degraded", True, False, failed_sources
+            )
 
         logger.info("Fetched %d candidate works", len(results))
         self._save_cache(results)
-        return results
+        if enabled_sources and failed_sources == enabled_sources:
+            return CandidateFetchOutcome(results, "failed", False, False, failed_sources)
+        status = "degraded" if failed_sources else "succeeded"
+        return CandidateFetchOutcome(results, status, False, True, failed_sources)
 
     def _run_fetch_source(self, source_name: str, fetcher) -> tuple[List[CandidateWork], bool]:
         try:

--- a/src/fetch_new.py
+++ b/src/fetch_new.py
@@ -511,6 +511,7 @@ class CandidateFetcher:
                     url=entry.get("link"),
                     published=published,
                     venue="arXiv",
+                    is_preprint=True,
                     extra={"primary_category": entry.get("arxiv_primary_category", {}).get("term")},
                 )
             )
@@ -551,6 +552,7 @@ class CandidateFetcher:
                     url=rel_link,
                     published=_parse_date(entry.get("date")),
                     venue=base,
+                    is_preprint=True,
                     extra={"category": entry.get("category"), "version": entry.get("version")},
                 )
             )

--- a/src/fetch_new.py
+++ b/src/fetch_new.py
@@ -229,6 +229,7 @@ class CandidateFetcher:
             url=item.get("url"),
             published=_parse_date(item.get("published_at")),
             venue=item.get("venue"),
+            is_preprint=(item.get("is_preprint") if isinstance(item.get("is_preprint"), bool) else None),
             metrics={str(key): float(value) for key, value in metrics.items() if _is_number(value)},
             extra={key: value for key, value in extra.items() if value is not None},
         )
@@ -291,6 +292,7 @@ class CandidateFetcher:
     @staticmethod
     def _serialize_candidate(candidate: CandidateWork) -> dict:
         data = candidate.dict()
+        data["is_preprint"] = candidate.is_preprint
         data["published"] = ensure_isoformat(candidate.published)
         return data
 

--- a/src/models.py
+++ b/src/models.py
@@ -71,6 +71,8 @@ class CandidateWork(BaseModel):
     url: Optional[str] = None
     published: Optional[datetime] = None
     venue: Optional[str] = None
+    # Excluded from the legacy dump shape; E5 projectors/cache transport it explicitly.
+    is_preprint: Optional[bool] = Field(default=None, exclude=True)
     metrics: Dict[str, float] = Field(default_factory=dict)
     extra: Dict[str, object] = Field(default_factory=dict)
 
@@ -88,6 +90,8 @@ class RankedWork(CandidateWork):
     similarity: float
     recency_score: float
     metric_score: float
+    # Additive provenance for E5; exclusion preserves the frozen E0 RankedWork shape.
+    altmetric_score: float = Field(default=0.0, exclude=True)
     author_bonus: float
     venue_bonus: float
     journal_quality: float = 1.0

--- a/src/score_rank.py
+++ b/src/score_rank.py
@@ -174,6 +174,7 @@ class WorkRanker:
                     similarity=similarity,
                     recency_score=recency_score,
                     metric_score=citation_score,
+                    altmetric_score=altmetric_score,
                     author_bonus=author_bonus,
                     venue_bonus=venue_bonus,
                     journal_quality=journal_quality,

--- a/tests/E5B_RED_BASELINE.md
+++ b/tests/E5B_RED_BASELINE.md
@@ -1,0 +1,8 @@
+# E5B red baseline
+
+At `v2-e5a-baseline` (`874c3e3e19ea3399f5bde3b4a9db6899c5fdf3e1`), the focused
+E5B suite fails during collection because `zotwatch.results` does not exist.
+This is the expected red evidence for the versioned recommendation/result and
+atomic output-publication contracts. The public candidate mapping test also
+defines the intentional BUG-F1 metadata transport change; it does not change
+candidate selection or ranking.

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,6 +30,11 @@ PYTHONHASHSEED=0 TZ=UTC OMP_NUM_THREADS=1 /tmp/zotwatch-e0-venv/bin/python -m py
 | [test_runtime_config_e5.py](test_runtime_config_e5.py) | E5A Basic v2 effective settings、engine-owned public connection、legacy runtime isolation |
 | [test_runtime_preflight_e5.py](test_runtime_preflight_e5.py) | E5A output/provider capability、credential presence 与 explicit Zotero verification |
 | [test_runtime_cli_e5a.py](test_runtime_cli_e5a.py) | E5A v2 dispatch、side-effect-free rejection、legacy-only option boundary |
+| [test_recommendation_contract_e5.py](test_recommendation_contract_e5.py) | E5B recommendation JSON v1、七分项 additive score provenance、显式 preprint metadata |
+| [test_run_manifest_e5.py](test_run_manifest_e5.py) | E5B private run manifest、stage finalization、sanitized symbolic errors |
+| [test_candidate_outcome_e5.py](test_candidate_outcome_e5.py) | E5B complete/partial/stale/unavailable candidate acquisition classification |
+| [test_output_publication_e5.py](test_output_publication_e5.py) | E5B immutable generation、authoritative pointer、artifact whitelist、失败保留旧输出 |
+| [test_exit_codes_e5.py](test_exit_codes_e5.py) | E5B machine result、relative artifact references、numeric/symbolic error boundary |
 | [test_candidates.py](test_candidates.py) | 冻结 public v1 分页/映射，来源路由、12 小时 cache、故障回退与 Crossref 补抓 |
 | [test_profile_ranking_outputs.py](test_profile_ranking_outputs.py) | profile、真实 FAISS 保存/读取/检索、排名分项及稳定 tie、labels、recency 边界、SJR、RSS/HTML 完整 golden |
 | [test_pipeline_http.py](test_pipeline_http.py) | CLI profile → watch 的真实本地链路、HTTP 重试/错误、离线防护自检 |

--- a/tests/installed_probe.py
+++ b/tests/installed_probe.py
@@ -120,7 +120,7 @@ ai:
     rerank: {enabled: false}
     summary: {enabled: false}
 outputs:
-  formats: [rss, html]
+  formats: [rss, html, json]
   publish: false
 """)
 ingest_zotero_api.ZoteroIngestor.run = lambda *a, **kw: SimpleNamespace(
@@ -135,7 +135,10 @@ v2_common = [
 assert public_main(["profile", *v2_common]) == 0
 assert public_main(["watch", *v2_common]) == 0
 assert (v2_reports / "feed.xml").read_bytes() == (reports / "feed.xml").read_bytes()
-assert (v2_reports / "report-20260114.html").is_file()
+assert (v2_reports / "report.html").is_file()
+assert json.loads((v2_reports / "recommendations.json").read_text())["schema_version"] == 1
+output_pointer = json.loads((v2_reports / ".zotwatch-output/latest-success.json").read_text())
+assert all(item["path"].startswith(".zotwatch-output/generations/") for item in output_pointer["artifacts"])
 print(json.dumps({
     "cli_module": cli.__file__,
     "state": str(state),
@@ -143,5 +146,6 @@ print(json.dumps({
     "profile": str(generation / "profile.json"),
     "manifest": str(generation / "state-manifest.json"),
     "v2_feed": str(v2_reports / "feed.xml"),
-    "v2_report": str(v2_reports / "report-20260114.html"),
+    "v2_report": str(v2_reports / "report.html"),
+    "v2_json": str(v2_reports / "recommendations.json"),
 }))

--- a/tests/test_candidate_outcome_e5.py
+++ b/tests/test_candidate_outcome_e5.py
@@ -1,0 +1,28 @@
+from datetime import timedelta
+
+import requests
+
+from src.fetch_new import CandidateFetcher
+from .helpers import NOW
+from .test_candidates import set_cache
+
+
+def test_all_candidate_sources_unavailable_is_failed_not_successful_empty(workspace, settings, monkeypatch):
+    fetcher = CandidateFetcher(settings, workspace)
+    monkeypatch.setattr(fetcher, "_fetch_public_candidates", lambda *args: (_ for _ in ()).throw(requests.ConnectionError()))
+    monkeypatch.setattr(fetcher, "_fetch_crossref_top_venues", lambda *args: [])
+    outcome = fetcher.fetch_with_outcome()
+    assert outcome.status == "failed"
+    assert outcome.candidates == []
+    assert outcome.request_complete is False
+
+
+def test_stale_candidate_fallback_is_degraded(workspace, settings, candidates, monkeypatch):
+    fetcher = CandidateFetcher(settings, workspace)
+    set_cache(fetcher, candidates[:1], 13)
+    monkeypatch.setattr(fetcher, "_fetch_public_candidates", lambda *args: (_ for _ in ()).throw(requests.ConnectionError()))
+    monkeypatch.setattr(fetcher, "_fetch_crossref_top_venues", lambda *args: [])
+    outcome = fetcher.fetch_with_outcome()
+    assert outcome.status == "degraded"
+    assert outcome.used_cache is True
+    assert outcome.candidates[0].identifier == "alpha"

--- a/tests/test_config_installation.py
+++ b/tests/test_config_installation.py
@@ -35,6 +35,8 @@ def test_wheel_and_sdist_include_e2_engine_resources():
         assert "zotwatch/providers/registry.py" in names
         assert "zotwatch/runtime/config.py" in names
         assert "zotwatch/runtime/preflight.py" in names
+        assert "zotwatch/results/publication.py" in names
+        assert "zotwatch/resources/recommendations-v1.schema.json" in names
     with tarfile.open(next(dist.glob("*.tar.gz"))) as archive:
         names = archive.getnames()
         assert any(name.endswith("zotwatch/resources/config-v2.schema.json") for name in names)
@@ -53,7 +55,7 @@ def test_installed_validate_works_outside_checkout(kind, fixture, tmp_path):
 
 
 @pytest.mark.parametrize("kind", ["WHEEL", "EDITABLE"])
-def test_installed_rejects_secret_fields_and_unavailable_json(kind, tmp_path):
+def test_installed_rejects_secret_fields_and_accepts_json_capability(kind, tmp_path):
     python = configured(f"E1_{kind}_PYTHON")
     invalid = _v2_workspace(tmp_path, "invalid-secret.yaml")
     result = run(
@@ -67,7 +69,8 @@ def test_installed_rejects_secret_fields_and_unavailable_json(kind, tmp_path):
 
     valid = _v2_workspace(tmp_path, "minimal.yaml")
     result = run(
-        [python.parent / "zotwatch", "watch", "--workspace", valid], valid, success=False
+        [python.parent / "zotwatch", "runtime", "preflight", "--workspace", valid],
+        valid, success=False,
     )
     assert result.returncode == 3
-    assert "OUTPUT_FORMAT_UNAVAILABLE" in result.stderr
+    assert "CREDENTIAL_MISSING" in result.stderr

--- a/tests/test_exit_codes_e5.py
+++ b/tests/test_exit_codes_e5.py
@@ -1,0 +1,115 @@
+import json
+from types import SimpleNamespace
+
+from src import cli as engine_cli
+from src import fetch_new
+from src.storage import ProfileStorage
+from zotwatch import cli
+from zotwatch.results.models import ArtifactReference, RunError, RunResult
+from zotwatch.results.recorder import RunRecorder
+
+from .test_runtime_cli_e5a import credentials, write_config
+
+
+def test_machine_result_is_single_closed_json_object(workspace, monkeypatch, capsys):
+    write_config(workspace, formats=("json",))
+    credentials(monkeypatch)
+    artifact = ArtifactReference(
+        path=".zotwatch-output/generations/run-1/recommendations.json",
+        sha256="a" * 64,
+        size_bytes=42,
+        media_type="application/json",
+        publishable=True,
+    )
+    monkeypatch.setattr(
+        engine_cli,
+        "run_watch_recorded",
+        lambda *args, **kwargs: RunResult(
+            run_id="run-1", status="succeeded", exit_code=0,
+            manifest_path="runs/run-1.json", output_generation_id="run-1",
+            artifacts=[artifact],
+        ),
+    )
+    assert cli.main([
+        "watch", "--workspace", str(workspace), "--machine-result"
+    ]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_name"] == "zotwatch-run-result"
+    assert payload["artifacts"][0]["path"].startswith(".zotwatch-output/generations/")
+    assert str(workspace) not in json.dumps(payload)
+
+
+def test_machine_failure_preserves_symbolic_code_and_numeric_category(workspace, monkeypatch, capsys):
+    write_config(workspace, formats=("rss",))
+    credentials(monkeypatch)
+    monkeypatch.setattr(
+        engine_cli,
+        "run_watch_recorded",
+        lambda *args, **kwargs: RunResult(
+            run_id="run-fail", status="failed", exit_code=4,
+            error=RunError(code="CANDIDATE_UNAVAILABLE", message="Candidate acquisition was unavailable.", diagnostic_id="d1"),
+        ),
+    )
+    assert cli.main([
+        "watch", "--workspace", str(workspace), "--machine-result"
+    ]) == 4
+    assert json.loads(capsys.readouterr().out)["error"]["code"] == "CANDIDATE_UNAVAILABLE"
+
+
+def test_machine_preflight_failure_is_recorded_without_secret_slot_names(workspace, monkeypatch, capsys):
+    write_config(workspace, formats=("json",))
+    monkeypatch.delenv("ZOTERO_USER_ID", raising=False)
+    monkeypatch.delenv("ZOTERO_API_KEY", raising=False)
+    assert cli.main([
+        "watch", "--workspace", str(workspace), "--machine-result"
+    ]) == 3
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"]["code"] == "CREDENTIAL_MISSING"
+    serialized = json.dumps(payload)
+    assert "ZOTERO_USER_ID" not in serialized
+    assert "ZOTERO_API_KEY" not in serialized
+    assert (workspace / "data" / payload["manifest_path"]).is_file()
+
+
+def test_strict_degradation_does_not_publish_outputs(workspace, settings, monkeypatch):
+    state = workspace / "state"
+    reports = workspace / "reports"
+    storage = ProfileStorage(state / "profile.sqlite")
+    storage.initialize()
+    handle = SimpleNamespace(generation_id="state-1", profile={})
+    monkeypatch.setattr(engine_cli.ZoteroIngestor, "run", lambda *args, **kwargs: None)
+    monkeypatch.setattr(engine_cli, "_ensure_computational_state", lambda *args, **kwargs: (handle, None))
+    monkeypatch.setattr(
+        fetch_new.CandidateFetcher,
+        "fetch_with_outcome",
+        lambda self: fetch_new.CandidateFetchOutcome([], "degraded", True, False, 1),
+    )
+    monkeypatch.setattr(engine_cli.DedupeEngine, "filter", lambda self, values: values)
+    monkeypatch.setattr(
+        engine_cli, "WorkRanker",
+        lambda *args, **kwargs: SimpleNamespace(rank=lambda values: []),
+    )
+    recorder = RunRecorder(
+        state, "watch", config_schema_version=2,
+        config_fingerprint_sha256="a" * 64, run_id="strict-run",
+    )
+    result = engine_cli.run_watch_recorded(
+        workspace, settings, storage, state_dir=state, reports_dir=reports,
+        output_formats=("json",), top=20, max_preprint_ratio=0.3,
+        journal_metrics="bundled", strict=True, recorder=recorder,
+    )
+    storage.close()
+    assert result.status == "degraded"
+    assert result.exit_code == 5
+    assert not (reports / ".zotwatch-output/latest-success.json").exists()
+
+
+def test_machine_config_failure_has_private_manifest(workspace, capsys):
+    (workspace / "config").rename(workspace / "legacy-config")
+    (workspace / "zotwatch.yaml").write_text("schema_version: 2\nunknown: true\n")
+    assert cli.main([
+        "watch", "--workspace", str(workspace), "--machine-result"
+    ]) == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"]["code"] == "CONFIG_INVALID"
+    assert (workspace / "data" / payload["manifest_path"]).is_file()

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -115,5 +115,6 @@ def test_installed_pipeline_matches_e0_goldens(kind, entry, workspace):
     assert (reports / "report-20260114.html").exists()
     assert Path(metadata["v2_feed"]).is_file()
     assert Path(metadata["v2_report"]).is_file()
+    assert Path(metadata["v2_json"]).is_file()
     assert before == {str(p): hashlib.sha256(p.read_bytes()).hexdigest() for p in package.rglob("*.py")}
     assert not any(p.suffix in {".sqlite", ".index", ".csv"} for p in package.rglob("*"))

--- a/tests/test_legacy_adapter.py
+++ b/tests/test_legacy_adapter.py
@@ -77,13 +77,7 @@ def test_validation_cli_is_offline_and_does_not_claim_ai_runtime(tmp_path, capsy
     assert "openrouter" not in output.out
 
 
-def test_public_cli_gates_e5a_json_and_rejects_mixed_modes(tmp_path, workspace, capsys):
-    v2_workspace = tmp_path / "v2-only"
-    v2_workspace.mkdir()
-    write_config(v2_workspace / "zotwatch.yaml", minimal_config())
-    assert public_cli.main(["watch", "--workspace", str(v2_workspace)]) == 3
-    assert "OUTPUT_FORMAT_UNAVAILABLE" in capsys.readouterr().err
-
+def test_public_cli_rejects_mixed_modes(tmp_path, workspace, capsys):
     write_config(workspace / "zotwatch.yaml", minimal_config())
     assert public_cli.main(["profile", "--workspace", str(workspace)]) == 2
     assert "CONFIG_MIXED_MODES" in capsys.readouterr().err

--- a/tests/test_output_publication_e5.py
+++ b/tests/test_output_publication_e5.py
@@ -56,3 +56,24 @@ def test_failed_render_preserves_previous_generation_and_aliases(tmp_path):
 def test_output_allowlist_rejects_unsafe_artifact_names(tmp_path, name):
     with pytest.raises(PublicationError):
         OutputPublisher(tmp_path).publish("run-1", {name: render_text("x")})
+
+
+def test_alias_failure_after_pointer_does_not_invalidate_authoritative_generation(tmp_path, monkeypatch):
+    reports = tmp_path / "reports"
+    publisher = OutputPublisher(reports)
+    original = publisher._atomic_bytes
+
+    def fail_alias(path, content):
+        if path == reports / "feed.xml":
+            raise OSError("synthetic alias failure")
+        return original(path, content)
+
+    monkeypatch.setattr(publisher, "_atomic_bytes", fail_alias)
+    result = publisher.publish("run-1", {"feed.xml": render_text("<rss/>")})
+    assert result.generation_id == "run-1"
+    pointer = json.loads((reports / ".zotwatch-output/latest-success.json").read_text())
+    assert pointer["generation_id"] == "run-1"
+    assert not (reports / "feed.xml").exists()
+
+    OutputPublisher(reports)._reconcile_aliases()
+    assert (reports / "feed.xml").read_text() == "<rss/>"

--- a/tests/test_output_publication_e5.py
+++ b/tests/test_output_publication_e5.py
@@ -17,7 +17,7 @@ def test_successful_generation_is_authoritative_and_aliases_are_compatibility_on
     publisher = OutputPublisher(reports)
     published = publisher.publish(
         "run-1",
-        {"recommendations.json": render_text('{"schema_version":1}\n'),
+        {"recommendations.json": render_text('{"schema_name":"zotwatch-recommendations","schema_version":1}\n'),
          "feed.xml": render_text("<rss/>"),
          "report.html": render_text("<html></html>")},
     )
@@ -31,7 +31,7 @@ def test_successful_generation_is_authoritative_and_aliases_are_compatibility_on
     for artifact in published.artifacts:
         ArtifactReference.model_validate(artifact.model_dump(mode="json"))
         assert artifact.sha256 and artifact.size_bytes > 0 and artifact.publishable
-    assert (reports / "recommendations.json").read_text() == '{"schema_version":1}\n'
+    assert json.loads((reports / "recommendations.json").read_text())["schema_version"] == 1
 
 
 def test_failed_render_preserves_previous_generation_and_aliases(tmp_path):

--- a/tests/test_output_publication_e5.py
+++ b/tests/test_output_publication_e5.py
@@ -1,0 +1,58 @@
+import json
+
+import pytest
+
+from zotwatch.results.models import ArtifactReference
+from zotwatch.results.publication import OutputPublisher, PublicationError
+
+
+def render_text(value):
+    def render(path):
+        path.write_text(value, encoding="utf-8")
+    return render
+
+
+def test_successful_generation_is_authoritative_and_aliases_are_compatibility_only(tmp_path):
+    reports = tmp_path / "reports"
+    publisher = OutputPublisher(reports)
+    published = publisher.publish(
+        "run-1",
+        {"recommendations.json": render_text('{"schema_version":1}\n'),
+         "feed.xml": render_text("<rss/>"),
+         "report.html": render_text("<html></html>")},
+    )
+    pointer = json.loads((reports / ".zotwatch-output/latest-success.json").read_text())
+    assert pointer["generation_id"] == "run-1"
+    assert {artifact.path for artifact in published.artifacts} == {
+        ".zotwatch-output/generations/run-1/recommendations.json",
+        ".zotwatch-output/generations/run-1/feed.xml",
+        ".zotwatch-output/generations/run-1/report.html",
+    }
+    for artifact in published.artifacts:
+        ArtifactReference.model_validate(artifact.model_dump(mode="json"))
+        assert artifact.sha256 and artifact.size_bytes > 0 and artifact.publishable
+    assert (reports / "recommendations.json").read_text() == '{"schema_version":1}\n'
+
+
+def test_failed_render_preserves_previous_generation_and_aliases(tmp_path):
+    reports = tmp_path / "reports"
+    publisher = OutputPublisher(reports)
+    publisher.publish("good", {"feed.xml": render_text("<rss>good</rss>")})
+    pointer_before = (reports / ".zotwatch-output/latest-success.json").read_bytes()
+    alias_before = (reports / "feed.xml").read_bytes()
+
+    def fail(path):
+        path.write_text("partial", encoding="utf-8")
+        raise RuntimeError("secret upstream text")
+
+    with pytest.raises(PublicationError):
+        publisher.publish("bad", {"feed.xml": fail, "report.html": render_text("later")})
+    assert (reports / ".zotwatch-output/latest-success.json").read_bytes() == pointer_before
+    assert (reports / "feed.xml").read_bytes() == alias_before
+    assert not (reports / ".zotwatch-output/generations/bad").exists()
+
+
+@pytest.mark.parametrize("name", ["../secret", "/absolute", "nested/file", "unknown.txt"])
+def test_output_allowlist_rejects_unsafe_artifact_names(tmp_path, name):
+    with pytest.raises(PublicationError):
+        OutputPublisher(tmp_path).publish("run-1", {name: render_text("x")})

--- a/tests/test_recommendation_contract_e5.py
+++ b/tests/test_recommendation_contract_e5.py
@@ -1,10 +1,13 @@
 import json
 import math
 
+import jsonschema
+
 from src.fetch_new import CandidateFetcher
 from src.models import CandidateWork, RankedWork
 from zotwatch.results.models import RecommendationDocument
 from zotwatch.results.projector import project_recommendations
+from zotwatch.resources import contract_schema_path
 
 
 def ranked_work(**changes):
@@ -20,7 +23,7 @@ def ranked_work(**changes):
         metrics={"cited_by": 7.0, "altmetric": 3.0},
         extra={"public_id": "public-1", "private": "must-not-project"},
         is_preprint=True,
-        score=1.25,
+        score=0.855,
         similarity=0.5,
         recency_score=1.0,
         metric_score=2.0,
@@ -41,6 +44,8 @@ def test_recommendation_v1_has_complete_additive_score_provenance(settings):
         [work], settings.scoring.weights, run_id="run-1", generated_at="2026-01-15T12:00:00Z"
     )
     validated = RecommendationDocument.model_validate(document.model_dump(mode="json"))
+    with contract_schema_path("recommendations-v1.schema.json") as schema_path:
+        jsonschema.validate(validated.model_dump(mode="json"), json.loads(schema_path.read_text()))
     item = validated.recommendations[0]
     assert list(item.score_breakdown) == [
         "similarity", "recency", "citations", "altmetric", "journal_quality",

--- a/tests/test_recommendation_contract_e5.py
+++ b/tests/test_recommendation_contract_e5.py
@@ -1,0 +1,71 @@
+import json
+import math
+
+from src.fetch_new import CandidateFetcher
+from src.models import CandidateWork, RankedWork
+from zotwatch.results.models import RecommendationDocument
+from zotwatch.results.projector import project_recommendations
+
+
+def ranked_work(**changes):
+    values = dict(
+        source="public-api",
+        identifier="work-1",
+        title="A useful paper",
+        abstract="Safe public abstract",
+        authors=["A. Author"],
+        doi="10.1000/example",
+        url="https://example.invalid/work-1",
+        venue="Example Journal",
+        metrics={"cited_by": 7.0, "altmetric": 3.0},
+        extra={"public_id": "public-1", "private": "must-not-project"},
+        is_preprint=True,
+        score=1.25,
+        similarity=0.5,
+        recency_score=1.0,
+        metric_score=2.0,
+        altmetric_score=1.0,
+        author_bonus=1.0,
+        venue_bonus=0.0,
+        journal_quality=1.5,
+        journal_sjr=2.4,
+        label="must_read",
+    )
+    values.update(changes)
+    return RankedWork(**values)
+
+
+def test_recommendation_v1_has_complete_additive_score_provenance(settings):
+    work = ranked_work()
+    document = project_recommendations(
+        [work], settings.scoring.weights, run_id="run-1", generated_at="2026-01-15T12:00:00Z"
+    )
+    validated = RecommendationDocument.model_validate(document.model_dump(mode="json"))
+    item = validated.recommendations[0]
+    assert list(item.score_breakdown) == [
+        "similarity", "recency", "citations", "altmetric", "journal_quality",
+        "author_bonus", "venue_bonus",
+    ]
+    assert math.isclose(
+        item.score,
+        sum(component.weighted_contribution for component in item.score_breakdown.values()),
+        rel_tol=0,
+        abs_tol=1e-12,
+    )
+    assert item.public_id == "public-1"
+    assert item.is_preprint is True
+    assert "private" not in json.dumps(item.model_dump(mode="json"))
+
+
+def test_public_preprint_metadata_is_explicitly_transported(workspace, settings):
+    fetcher = CandidateFetcher(settings, workspace)
+    explicit = fetcher._candidate_from_public_api({
+        "id": "p1", "source": "crossref", "source_identifier": "x", "title": "Title",
+        "is_preprint": False,
+    })
+    unknown = fetcher._candidate_from_public_api({
+        "id": "p2", "source": "unknown", "source_identifier": "y", "title": "Other",
+    })
+    assert explicit.is_preprint is False
+    assert unknown.is_preprint is None
+    assert CandidateWork(source="arxiv", identifier="z", title="Z").is_preprint is None

--- a/tests/test_run_manifest_e5.py
+++ b/tests/test_run_manifest_e5.py
@@ -1,0 +1,34 @@
+import json
+
+from zotwatch.results.recorder import RunRecorder
+
+
+def test_private_manifest_finalizes_stages_and_returns_relative_reference(tmp_path):
+    recorder = RunRecorder(
+        tmp_path, "watch", config_schema_version=2,
+        config_fingerprint_sha256="a" * 64, run_id="run-1",
+    )
+    recorder.start("config_validation")
+    recorder.finish("config_validation")
+    recorder.start("candidate_fetch")
+    recorder.degrade("candidate_fetch", "CANDIDATE_PARTIAL", count=2)
+    result = recorder.finalize(status="degraded", exit_code=0)
+    assert result.manifest_path == "runs/run-1.json"
+    manifest = json.loads((tmp_path / result.manifest_path).read_text())
+    assert manifest["status"] == "degraded"
+    assert all(stage["status"] not in {"pending", "running"} for stage in manifest["stages"])
+    text = json.dumps(manifest)
+    assert str(tmp_path) not in text
+    assert "CANDIDATE_PARTIAL" in text
+
+
+def test_error_catalog_never_serializes_raw_exception(tmp_path):
+    recorder = RunRecorder(
+        tmp_path, "profile", config_schema_version=None,
+        config_fingerprint_sha256=None, run_id="run-2",
+    )
+    recorder.fail("zotero_sync", "unknown user controlled secret")
+    result = recorder.finalize(status="failed", exit_code=4, error_code="unknown user controlled secret")
+    payload = (tmp_path / result.manifest_path).read_text()
+    assert "unknown user controlled secret" not in payload
+    assert payload.count("INTERNAL_ERROR") >= 1

--- a/tests/test_runtime_cli_e5a.py
+++ b/tests/test_runtime_cli_e5a.py
@@ -9,6 +9,7 @@ from src.computational_state import pseudonymous_library_identity
 from src.models import ZoteroItem
 from src.storage import ProfileStorage
 from zotwatch import cli
+from zotwatch.results.models import RunResult
 
 from .helpers import FIXTURES, FixedVectors, read_json
 from .test_config_v2 import minimal_config
@@ -39,30 +40,36 @@ def test_v2_watch_dispatches_existing_pipeline_with_config_values(
     calls = []
     monkeypatch.setattr(
         legacy_cli,
-        "run_watch",
-        lambda base, settings, storage, **kwargs: calls.append((base, settings, kwargs)),
+        "run_watch_recorded",
+        lambda base, settings, storage, **kwargs: (
+            calls.append((base, settings, kwargs))
+            or RunResult(run_id="test-run", status="succeeded", exit_code=0)
+        ),
     )
     assert cli.main(["watch", "--workspace", str(workspace)]) == 0
     assert len(calls) == 1
     base, settings, kwargs = calls[0]
     assert base == workspace
     assert settings.sources.public_api.enabled
-    assert kwargs["rss"] is True
-    assert kwargs["report"] is True
+    assert kwargs["output_formats"] == ("rss", "html")
     assert kwargs["top"] == 20
-    assert kwargs["push"] is False
     assert kwargs["journal_metrics"] == "bundled"
 
 
-def test_json_and_ai_fail_before_pipeline_side_effects(workspace, monkeypatch, capsys):
+def test_json_executes_but_ai_still_fails_before_pipeline_side_effects(workspace, monkeypatch, capsys):
     credentials(monkeypatch)
     called = []
-    monkeypatch.setattr(legacy_cli, "run_watch", lambda *args, **kwargs: called.append(1))
+    monkeypatch.setattr(
+        legacy_cli, "run_watch_recorded",
+        lambda *args, **kwargs: called.append(1) or RunResult(
+            run_id="json-run", status="succeeded", exit_code=0
+        ),
+    )
 
     write_config(workspace, formats=("json",))
-    assert cli.main(["watch", "--workspace", str(workspace)]) == 3
-    assert "OUTPUT_FORMAT_UNAVAILABLE" in capsys.readouterr().err
-    assert called == []
+    assert cli.main(["watch", "--workspace", str(workspace)]) == 0
+    assert called == [1]
+    called.clear()
 
     ai = {
         "services": {"s": {"provider": "openrouter", "model": "some-model"}},
@@ -92,7 +99,7 @@ def test_legacy_and_basic_v2_share_ranking_and_rss_html_content(
 ):
     v2_workspace = workspace / "v2-workspace"
     v2_workspace.mkdir()
-    write_config(v2_workspace)
+    write_config(v2_workspace, formats=("rss", "html", "json"))
     identity = pseudonymous_library_identity("user", "123456")
     legacy_state = workspace / "legacy-state"
     v2_state = workspace / "v2-state"
@@ -113,7 +120,11 @@ def test_legacy_and_basic_v2_share_ranking_and_rss_html_content(
     )
     monkeypatch.setattr(build_profile, "TextVectorizer", FixedVectors)
     monkeypatch.setattr(score_rank, "TextVectorizer", FixedVectors)
-    monkeypatch.setattr(fetch_new.CandidateFetcher, "fetch_all", lambda self: candidates)
+    monkeypatch.setattr(
+        fetch_new.CandidateFetcher,
+        "fetch_with_outcome",
+        lambda self: fetch_new.CandidateFetchOutcome(candidates, "succeeded", False, True),
+    )
     captures = []
     original_rank = score_rank.WorkRanker.rank
 
@@ -145,5 +156,15 @@ def test_legacy_and_basic_v2_share_ranking_and_rss_html_content(
     assert captures[0] == captures[1]
     assert (legacy_reports / "feed.xml").read_bytes() == (v2_reports / "feed.xml").read_bytes()
     assert (legacy_reports / "report-20260114.html").read_bytes() == (
-        v2_reports / "report-20260114.html"
+        v2_reports / "report.html"
     ).read_bytes()
+    recommendations = read_json(v2_reports / "recommendations.json")
+    assert recommendations["schema_name"] == "zotwatch-recommendations"
+    assert recommendations["schema_version"] == 1
+    assert len(recommendations["recommendations"]) == 4
+    pointer = read_json(v2_reports / ".zotwatch-output/latest-success.json")
+    assert pointer["generation_id"]
+    assert all(
+        item["path"].startswith(".zotwatch-output/generations/")
+        for item in pointer["artifacts"]
+    )

--- a/tests/test_runtime_preflight_e5.py
+++ b/tests/test_runtime_preflight_e5.py
@@ -42,13 +42,13 @@ def test_basic_rss_html_needs_no_ai_or_public_pool_credential(workspace, monkeyp
     assert "synthetic-zotero-key" not in report.model_dump_json()
 
 
-def test_e5a_json_is_explicitly_unavailable(workspace, monkeypatch):
+def test_e5b_json_is_runtime_supported(workspace, monkeypatch):
     write_config(workspace, minimal_config())
     monkeypatch.setenv("ZOTERO_USER_ID", "12345")
     monkeypatch.setenv("ZOTERO_API_KEY", "synthetic-zotero-key")
     report = preflight(load_effective_runtime(workspace))
-    assert not report.ready
-    assert report.error_code == "OUTPUT_FORMAT_UNAVAILABLE"
+    assert report.ready
+    assert report.error_code is None
 
 
 def test_registered_but_unimplemented_ai_is_not_executable(workspace, monkeypatch):

--- a/zotwatch/cli.py
+++ b/zotwatch/cli.py
@@ -36,6 +36,8 @@ def _v2_parser() -> argparse.ArgumentParser:
     parser.add_argument("--top", type=int)
     parser.add_argument("--push", action="store_true")
     parser.add_argument("--journal-metrics")
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--machine-result", action="store_true")
     return parser
 
 
@@ -101,6 +103,8 @@ def _run_v2(arguments: list[str]) -> int:
     from src.storage import ProfileStorage
     from zotwatch.paths import RuntimePaths
     from zotwatch.runtime import load_effective_runtime, preflight
+    from zotwatch.results.recorder import RunRecorder
+    from zotwatch.config import ConfigError
 
     args = _v2_parser().parse_args(arguments)
     paths = RuntimePaths.resolve(
@@ -110,46 +114,81 @@ def _run_v2(arguments: list[str]) -> int:
         reports_dir=args.reports_dir,
     )
     load_dotenv(paths.workspace / ".env")
-    effective = load_effective_runtime(paths.workspace)
+    try:
+        effective = load_effective_runtime(paths.workspace)
+    except ConfigError:
+        recorder = RunRecorder(
+            paths.state, args.command, config_schema_version=None,
+            config_fingerprint_sha256=None,
+        )
+        recorder.fail("config_validation", "CONFIG_INVALID")
+        result = recorder.finalize(
+            status="failed", exit_code=2, error_code="CONFIG_INVALID"
+        )
+        return _emit_result(result, machine=args.machine_result)
+    recorder = RunRecorder(
+        paths.state,
+        args.command,
+        config_schema_version=effective.config_schema_version,
+        config_fingerprint_sha256=effective.config_fingerprint_sha256,
+    )
     forbidden = ("--rss", "--report", "--top", "--push", "--journal-metrics")
     if any(_has_option(arguments, option) for option in forbidden):
-        print(
-            "CONFIG_OPTION_UNSUPPORTED: Basic v2 runtime options come from zotwatch.yaml",
-            file=sys.stderr,
+        recorder.fail("config_validation", "CONFIG_OPTION_UNSUPPORTED")
+        result = recorder.finalize(
+            status="failed", exit_code=2, error_code="CONFIG_OPTION_UNSUPPORTED"
         )
-        return 2
+        return _emit_result(result, machine=args.machine_result)
+    recorder.start("config_validation")
+    recorder.finish("config_validation")
+    recorder.start("credential_preflight")
     report = preflight(effective)
     if not report.ready:
-        print(f"{report.error_code}: runtime preflight failed", file=sys.stderr)
-        return 3
-
+        recorder.fail("credential_preflight", report.error_code)
+        result = recorder.finalize(
+            status="failed", exit_code=3, error_code=report.error_code
+        )
+        return _emit_result(result, machine=args.machine_result)
+    recorder.finish("credential_preflight")
     setup_logging(verbose=args.verbose)
     storage = ProfileStorage(paths.state / "profile.sqlite")
     try:
         if args.command == "profile":
-            engine_cli.run_profile(
+            result = engine_cli.run_profile_recorded(
                 paths.workspace,
                 effective.settings,
                 storage,
                 full=args.full or args.weekly,
                 state_dir=paths.state,
+                recorder=recorder,
             )
         else:
-            engine_cli.run_watch(
+            result = engine_cli.run_watch_recorded(
                 paths.workspace,
                 effective.settings,
                 storage,
-                rss="rss" in effective.output_formats,
-                report="html" in effective.output_formats,
+                output_formats=effective.output_formats,
                 top=effective.top_n,
-                push=False,
+                max_preprint_ratio=effective.max_preprint_ratio,
                 state_dir=paths.state,
                 reports_dir=paths.reports,
                 journal_metrics=effective.journal_metrics,
+                strict=args.strict,
+                recorder=recorder,
             )
     finally:
         storage.close()
-    return 0
+    return _emit_result(result, machine=args.machine_result)
+
+
+def _emit_result(result, *, machine: bool) -> int:
+    if machine:
+        print(result.model_dump_json())
+    elif result.status == "failed":
+        print(f"{result.error.code}: {result.error.message}", file=sys.stderr)
+    else:
+        print(f"Run {result.run_id} {result.status}.")
+    return result.exit_code
 
 
 def main(argv=None):

--- a/zotwatch/resources/__init__.py
+++ b/zotwatch/resources/__init__.py
@@ -13,3 +13,15 @@ def journal_metrics_path(selection: str, workspace: Path):
             yield path
     else:
         yield (workspace / selection).resolve()
+
+
+@contextmanager
+def contract_schema_path(name: str):
+    if name not in {
+        "recommendations-v1.schema.json",
+        "run-manifest-v1.schema.json",
+        "run-result-v1.schema.json",
+    }:
+        raise ValueError("Unknown ZotWatch contract schema")
+    with as_file(files(__package__).joinpath(name)) as path:
+        yield path

--- a/zotwatch/resources/recommendations-v1.schema.json
+++ b/zotwatch/resources/recommendations-v1.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zotwatch.dev/contracts/recommendations-v1.schema.json",
+  "title": "ZotWatch Recommendations v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_name", "schema_version", "run_id", "generated_at", "recommendations"],
+  "properties": {
+    "schema_name": {"const": "zotwatch-recommendations"},
+    "schema_version": {"const": 1},
+    "run_id": {"type": "string"},
+    "generated_at": {"type": "string"},
+    "recommendations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["rank", "work_key", "public_id", "source", "identifier", "title", "abstract", "authors", "doi", "url", "published", "venue", "is_preprint", "label", "score", "score_breakdown"],
+        "properties": {
+          "rank": {"type": "integer", "minimum": 1},
+          "work_key": {"type": "string"},
+          "public_id": {"type": ["string", "null"]},
+          "source": {"type": "string"},
+          "identifier": {"type": "string"},
+          "title": {"type": "string"},
+          "abstract": {"type": ["string", "null"]},
+          "authors": {"type": "array", "items": {"type": "string"}},
+          "doi": {"type": ["string", "null"]},
+          "url": {"type": ["string", "null"]},
+          "published": {"type": ["string", "null"]},
+          "venue": {"type": ["string", "null"]},
+          "is_preprint": {"type": ["boolean", "null"]},
+          "label": {"enum": ["must_read", "consider", "ignore"]},
+          "score": {"type": "number"},
+          "score_breakdown": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["similarity", "recency", "citations", "altmetric", "journal_quality", "author_bonus", "venue_bonus"],
+            "properties": {
+              "similarity": {"$ref": "#/$defs/component"},
+              "recency": {"$ref": "#/$defs/component"},
+              "citations": {"$ref": "#/$defs/component"},
+              "altmetric": {"$ref": "#/$defs/component"},
+              "journal_quality": {"$ref": "#/$defs/component"},
+              "author_bonus": {"$ref": "#/$defs/component"},
+              "venue_bonus": {"$ref": "#/$defs/component"}
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["raw_value", "weighted_contribution", "input_available"],
+      "properties": {
+        "raw_value": {"type": ["number", "null"]},
+        "weighted_contribution": {"type": "number"},
+        "input_available": {"type": "boolean"}
+      }
+    }
+  }
+}

--- a/zotwatch/resources/run-manifest-v1.schema.json
+++ b/zotwatch/resources/run-manifest-v1.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zotwatch.dev/contracts/run-manifest-v1.schema.json",
+  "title": "ZotWatch Private Run Manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_name", "schema_version", "run_id", "command", "status", "exit_code", "generated_at", "config_schema_version", "config_fingerprint_sha256", "state_generation_id", "output_generation_id", "stages", "artifacts", "error"],
+  "properties": {
+    "schema_name": {"const": "zotwatch-run-manifest"},
+    "schema_version": {"const": 1},
+    "run_id": {"type": "string"},
+    "command": {"enum": ["profile", "watch"]},
+    "status": {"enum": ["succeeded", "degraded", "failed"]},
+    "exit_code": {"enum": [0, 2, 3, 4, 5]},
+    "generated_at": {"type": "string"},
+    "config_schema_version": {"type": ["integer", "null"]},
+    "config_fingerprint_sha256": {"type": ["string", "null"]},
+    "state_generation_id": {"type": ["string", "null"]},
+    "output_generation_id": {"type": ["string", "null"]},
+    "stages": {"type": "array", "items": {"type": "object"}},
+    "artifacts": {"type": "array", "items": {"type": "object"}},
+    "error": {"type": ["object", "null"]}
+  }
+}

--- a/zotwatch/resources/run-result-v1.schema.json
+++ b/zotwatch/resources/run-result-v1.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zotwatch.dev/contracts/run-result-v1.schema.json",
+  "title": "ZotWatch Run Result v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_name", "schema_version", "run_id", "status", "exit_code", "error", "manifest_path", "state_generation_id", "output_generation_id", "artifacts"],
+  "properties": {
+    "schema_name": {"const": "zotwatch-run-result"},
+    "schema_version": {"const": 1},
+    "run_id": {"type": "string"},
+    "status": {"enum": ["succeeded", "degraded", "failed"]},
+    "exit_code": {"enum": [0, 2, 3, 4, 5]},
+    "error": {"type": ["object", "null"]},
+    "manifest_path": {"type": ["string", "null"]},
+    "state_generation_id": {"type": ["string", "null"]},
+    "output_generation_id": {"type": ["string", "null"]},
+    "artifacts": {"type": "array", "items": {"$ref": "#/$defs/artifact"}}
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256", "size_bytes", "media_type", "publishable"],
+      "properties": {
+        "path": {"type": "string"},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "size_bytes": {"type": "integer", "minimum": 0},
+        "media_type": {"type": "string"},
+        "publishable": {"type": "boolean"}
+      }
+    }
+  }
+}

--- a/zotwatch/results/__init__.py
+++ b/zotwatch/results/__init__.py
@@ -1,0 +1,5 @@
+"""Versioned recommendation and private run result contracts."""
+
+from .models import RunResult
+
+__all__ = ["RunResult"]

--- a/zotwatch/results/errors.py
+++ b/zotwatch/results/errors.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from .models import RunError
+
+
+ERROR_MESSAGES = {
+    "CONFIG_INVALID": "Configuration could not be validated.",
+    "CONFIG_MIXED_MODES": "Legacy and v2 configuration cannot be used together.",
+    "CONFIG_OPTION_UNSUPPORTED": "This command option is unavailable for the selected configuration.",
+    "OUTPUT_FORMAT_UNAVAILABLE": "A requested output format is unavailable in this engine revision.",
+    "CAPABILITY_UNAVAILABLE": "A configured capability has no executable runtime adapter.",
+    "CREDENTIAL_MISSING": "A required credential is not configured.",
+    "CREDENTIAL_MALFORMED": "A required credential has an invalid shape.",
+    "CREDENTIAL_VERIFICATION_FAILED": "Explicit credential verification failed.",
+    "ZOTERO_SYNC_FAILED": "Zotero synchronization failed.",
+    "STATE_INCOMPATIBLE": "The computational state is incompatible.",
+    "STATE_BUILD_FAILED": "The computational state could not be built.",
+    "STATE_CORRUPT": "The computational state is corrupt.",
+    "CANDIDATE_PARTIAL": "Some candidate sources were unavailable.",
+    "CANDIDATE_STALE_CACHE": "Candidate acquisition used a stale cached result.",
+    "CANDIDATE_UNAVAILABLE": "Candidate acquisition was unavailable.",
+    "CANDIDATE_PAYLOAD_INVALID": "A candidate response did not satisfy its contract.",
+    "DEDUPE_FAILED": "Candidate deduplication failed.",
+    "RANKING_FAILED": "Candidate ranking failed.",
+    "OUTPUT_CONTRACT_INVALID": "Recommendation output did not satisfy its contract.",
+    "OUTPUT_RENDER_FAILED": "Recommendation output could not be rendered.",
+    "OUTPUT_PUBLISH_FAILED": "Recommendation output could not be published.",
+    "ZOTERO_WRITEBACK_FAILED": "Zotero write-back failed.",
+    "INTERNAL_ERROR": "The run failed at an internal boundary.",
+}
+
+
+def run_error(code: str) -> RunError:
+    safe_code = code if code in ERROR_MESSAGES else "INTERNAL_ERROR"
+    return RunError(
+        code=safe_code,
+        message=ERROR_MESSAGES[safe_code],
+        diagnostic_id=uuid4().hex,
+    )
+
+
+__all__ = ["ERROR_MESSAGES", "run_error"]

--- a/zotwatch/results/models.py
+++ b/zotwatch/results/models.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class ContractModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class ScoreComponent(ContractModel):
+    raw_value: float | None
+    weighted_contribution: float
+    input_available: bool
+
+
+class RecommendationItem(ContractModel):
+    rank: int = Field(ge=1)
+    work_key: str = Field(min_length=1, max_length=512)
+    public_id: str | None = None
+    source: str
+    identifier: str
+    title: str
+    abstract: str | None = None
+    authors: list[str]
+    doi: str | None = None
+    url: str | None = None
+    published: str | None = None
+    venue: str | None = None
+    is_preprint: bool | None = None
+    label: Literal["must_read", "consider", "ignore"]
+    score: float
+    score_breakdown: dict[str, ScoreComponent]
+
+    @model_validator(mode="after")
+    def additive_score(self) -> "RecommendationItem":
+        expected = (
+            "similarity", "recency", "citations", "altmetric", "journal_quality",
+            "author_bonus", "venue_bonus",
+        )
+        if tuple(self.score_breakdown) != expected:
+            raise ValueError("score_breakdown must contain the seven ordered legacy components")
+        total = sum(item.weighted_contribution for item in self.score_breakdown.values())
+        if abs(total - self.score) > 1e-9:
+            raise ValueError("score must equal the additive weighted contributions")
+        return self
+
+
+class RecommendationDocument(ContractModel):
+    schema_name: Literal["zotwatch-recommendations"] = "zotwatch-recommendations"
+    schema_version: Literal[1] = 1
+    run_id: str
+    generated_at: str
+    recommendations: list[RecommendationItem]
+
+
+class ArtifactReference(ContractModel):
+    path: str
+    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    size_bytes: int = Field(ge=0)
+    media_type: str
+    publishable: bool
+
+    @field_validator("path")
+    @classmethod
+    def relative_safe_path(cls, value: str) -> str:
+        from pathlib import PurePosixPath
+        path = PurePosixPath(value)
+        if path.is_absolute() or ".." in path.parts or value in {"", "."}:
+            raise ValueError("artifact path must be a safe relative path")
+        return value
+
+
+StageStatus = Literal["pending", "running", "succeeded", "skipped", "degraded", "failed"]
+RunStatus = Literal["succeeded", "degraded", "failed"]
+
+
+class RunError(ContractModel):
+    code: str
+    message: str
+    diagnostic_id: str
+
+
+class StageRecord(ContractModel):
+    stage: Literal[
+        "config_validation", "credential_preflight", "zotero_sync",
+        "computational_state", "candidate_fetch", "dedupe", "ranking",
+        "output_render", "zotero_writeback", "output_publish",
+    ]
+    status: StageStatus
+    started_at: str | None = None
+    finished_at: str | None = None
+    count: int | None = None
+    error: RunError | None = None
+
+
+class RunManifest(ContractModel):
+    schema_name: Literal["zotwatch-run-manifest"] = "zotwatch-run-manifest"
+    schema_version: Literal[1] = 1
+    run_id: str
+    command: Literal["profile", "watch"]
+    status: RunStatus
+    exit_code: Literal[0, 2, 3, 4, 5]
+    generated_at: str
+    config_schema_version: int | None
+    config_fingerprint_sha256: str | None
+    state_generation_id: str | None = None
+    output_generation_id: str | None = None
+    stages: list[StageRecord]
+    artifacts: list[ArtifactReference] = Field(default_factory=list)
+    error: RunError | None = None
+
+
+class RunResult(ContractModel):
+    schema_name: Literal["zotwatch-run-result"] = "zotwatch-run-result"
+    schema_version: Literal[1] = 1
+    run_id: str
+    status: RunStatus
+    exit_code: Literal[0, 2, 3, 4, 5]
+    error: RunError | None = None
+    manifest_path: str | None = None
+    state_generation_id: str | None = None
+    output_generation_id: str | None = None
+    artifacts: list[ArtifactReference] = Field(default_factory=list)
+
+    @field_validator("manifest_path")
+    @classmethod
+    def safe_manifest_path(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        ArtifactReference.relative_safe_path(value)
+        return value
+
+
+__all__ = [
+    "ArtifactReference", "RecommendationDocument", "RecommendationItem", "RunError",
+    "RunManifest", "RunResult", "ScoreComponent", "StageRecord",
+]

--- a/zotwatch/results/models.py
+++ b/zotwatch/results/models.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections import OrderedDict
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator

--- a/zotwatch/results/projector.py
+++ b/zotwatch/results/projector.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from hashlib import sha256
+
+from src.models import RankedWork
+from src.settings import ScoreWeights
+
+from .models import RecommendationDocument, RecommendationItem, ScoreComponent
+
+
+def _component(raw: float | None, weight: float, available: bool) -> ScoreComponent:
+    return ScoreComponent(
+        raw_value=raw,
+        weighted_contribution=(float(raw) * float(weight)) if raw is not None else 0.0,
+        input_available=available,
+    )
+
+
+def _work_key(work: RankedWork) -> str:
+    stable = work.doi or f"{work.source}:{work.identifier}"
+    return sha256(stable.strip().lower().encode("utf-8")).hexdigest()
+
+
+def project_recommendations(
+    works: list[RankedWork],
+    weights: ScoreWeights,
+    *,
+    run_id: str,
+    generated_at: str,
+) -> RecommendationDocument:
+    projected = []
+    for rank, work in enumerate(works, start=1):
+        cited_available = any(key in work.metrics for key in ("cited_by", "is-referenced-by"))
+        alt_available = "altmetric" in work.metrics
+        breakdown = OrderedDict([
+            ("similarity", _component(work.similarity, weights.similarity, True)),
+            ("recency", _component(work.recency_score, weights.recency, work.published is not None)),
+            ("citations", _component(work.metric_score, weights.citations, cited_available)),
+            ("altmetric", _component(work.altmetric_score, weights.altmetric, alt_available)),
+            ("journal_quality", _component(work.journal_quality, getattr(weights, "journal_quality", 0.0), work.journal_sjr is not None)),
+            ("author_bonus", _component(work.author_bonus, weights.author_bonus, bool(work.authors))),
+            ("venue_bonus", _component(work.venue_bonus, weights.venue_bonus, work.venue is not None)),
+        ])
+        computed_score = sum(item.weighted_contribution for item in breakdown.values())
+        if abs(computed_score - work.score) > 1e-9:
+            raise ValueError("ranked score does not match its additive provenance")
+        projected.append(RecommendationItem(
+            rank=rank,
+            work_key=_work_key(work),
+            public_id=(str(work.extra["public_id"]) if work.extra.get("public_id") is not None else None),
+            source=work.source,
+            identifier=work.identifier,
+            title=work.title,
+            abstract=work.abstract,
+            authors=list(work.authors),
+            doi=work.doi,
+            url=work.url,
+            published=work.published.isoformat() if work.published else None,
+            venue=work.venue,
+            is_preprint=work.is_preprint,
+            label=work.label,
+            score=work.score,
+            score_breakdown=breakdown,
+        ))
+    return RecommendationDocument(run_id=run_id, generated_at=generated_at, recommendations=projected)
+
+
+__all__ = ["project_recommendations"]

--- a/zotwatch/results/publication.py
+++ b/zotwatch/results/publication.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+from typing import Callable
+from xml.etree import ElementTree
+
+from .models import ArtifactReference
+
+
+_ALLOWED = {
+    "recommendations.json": "application/json",
+    "feed.xml": "application/rss+xml",
+    "report.html": "text/html; charset=utf-8",
+}
+
+
+class PublicationError(RuntimeError):
+    """Sanitized output render/publication boundary error."""
+
+
+@dataclass(frozen=True)
+class PublishedGeneration:
+    generation_id: str
+    artifacts: tuple[ArtifactReference, ...]
+
+
+class OutputPublisher:
+    def __init__(self, reports_root: Path | str):
+        self.root = Path(reports_root)
+        self.internal = self.root / ".zotwatch-output"
+
+    def publish(
+        self,
+        run_id: str,
+        renderers: dict[str, Callable[[Path], object]],
+    ) -> PublishedGeneration:
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", run_id):
+            raise PublicationError("Invalid output generation identifier")
+        if not renderers or any(name not in _ALLOWED for name in renderers):
+            raise PublicationError("Output artifact is not in the publication allowlist")
+        staging = self.internal / "staging" / f"{run_id}.tmp"
+        generation = self.internal / "generations" / run_id
+        if generation.exists():
+            raise PublicationError("Output generation already exists")
+        try:
+            if staging.exists():
+                shutil.rmtree(staging)
+            staging.mkdir(parents=True)
+            for name, renderer in renderers.items():
+                target = staging / name
+                renderer(target)
+                self._validate(name, target)
+            artifacts = tuple(self._reference(run_id, name, staging / name) for name in renderers)
+            generation.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(staging, generation)
+            pointer = {
+                "schema_version": 1,
+                "generation_id": run_id,
+                "artifacts": [item.model_dump(mode="json") for item in artifacts],
+            }
+            self._atomic_bytes(
+                self.internal / "latest-success.json",
+                (json.dumps(pointer, sort_keys=True, separators=(",", ":")) + "\n").encode(),
+            )
+            for name in renderers:
+                self._atomic_bytes(self.root / name, (generation / name).read_bytes())
+            return PublishedGeneration(run_id, artifacts)
+        except PublicationError:
+            if staging.exists():
+                shutil.rmtree(staging, ignore_errors=True)
+            raise
+        except Exception as exc:
+            if staging.exists():
+                shutil.rmtree(staging, ignore_errors=True)
+            raise PublicationError("Output generation could not be rendered or published") from exc
+
+    @staticmethod
+    def _validate(name: str, path: Path) -> None:
+        if not path.is_file():
+            raise PublicationError("Output renderer did not create its artifact")
+        try:
+            if name == "recommendations.json":
+                payload = json.loads(path.read_text(encoding="utf-8"))
+                if payload.get("schema_name") != "zotwatch-recommendations" or payload.get("schema_version") != 1:
+                    raise PublicationError("Recommendation output contract is invalid")
+            elif name == "feed.xml":
+                ElementTree.parse(path)
+            else:
+                path.read_text(encoding="utf-8")
+        except PublicationError:
+            raise
+        except Exception as exc:
+            raise PublicationError("Rendered output is invalid") from exc
+
+    @staticmethod
+    def _reference(run_id: str, name: str, path: Path) -> ArtifactReference:
+        content = path.read_bytes()
+        return ArtifactReference(
+            path=f".zotwatch-output/generations/{run_id}/{name}",
+            sha256=sha256(content).hexdigest(),
+            size_bytes=len(content),
+            media_type=_ALLOWED[name],
+            publishable=True,
+        )
+
+    @staticmethod
+    def _atomic_bytes(path: Path, content: bytes) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_name(f".{path.name}.tmp")
+        with temporary.open("wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+
+
+__all__ = ["OutputPublisher", "PublicationError", "PublishedGeneration"]

--- a/zotwatch/results/publication.py
+++ b/zotwatch/results/publication.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from hashlib import sha256
 import json
+import logging
 import os
 from pathlib import Path
 import re
@@ -18,6 +19,7 @@ _ALLOWED = {
     "feed.xml": "application/rss+xml",
     "report.html": "text/html; charset=utf-8",
 }
+logger = logging.getLogger(__name__)
 
 
 class PublicationError(RuntimeError):
@@ -54,6 +56,7 @@ class OutputPublisher:
             raise PublicationError("Output generation already exists")
         phase = "render"
         try:
+            self._reconcile_aliases()
             if staging.exists():
                 shutil.rmtree(staging)
             staging.mkdir(parents=True)
@@ -75,7 +78,10 @@ class OutputPublisher:
                 (json.dumps(pointer, sort_keys=True, separators=(",", ":")) + "\n").encode(),
             )
             for name in renderers:
-                self._atomic_bytes(self.root / name, (generation / name).read_bytes())
+                try:
+                    self._atomic_bytes(self.root / name, (generation / name).read_bytes())
+                except OSError:
+                    logger.warning("Compatibility output alias could not be refreshed: %s", name)
             return PublishedGeneration(run_id, artifacts)
         except PublicationError:
             if staging.exists():
@@ -115,6 +121,23 @@ class OutputPublisher:
             media_type=_ALLOWED[name],
             publishable=True,
         )
+
+    def _reconcile_aliases(self) -> None:
+        pointer_path = self.internal / "latest-success.json"
+        if not pointer_path.exists():
+            return
+        try:
+            pointer = json.loads(pointer_path.read_text(encoding="utf-8"))
+            for raw in pointer.get("artifacts", []):
+                artifact = ArtifactReference.model_validate(raw)
+                name = Path(artifact.path).name
+                if name not in _ALLOWED:
+                    continue
+                source = self.root / artifact.path
+                if source.is_file() and sha256(source.read_bytes()).hexdigest() == artifact.sha256:
+                    self._atomic_bytes(self.root / name, source.read_bytes())
+        except Exception:
+            logger.warning("Previous compatibility aliases could not be reconciled")
 
     @staticmethod
     def _atomic_bytes(path: Path, content: bytes) -> None:

--- a/zotwatch/results/publication.py
+++ b/zotwatch/results/publication.py
@@ -23,6 +23,10 @@ _ALLOWED = {
 class PublicationError(RuntimeError):
     """Sanitized output render/publication boundary error."""
 
+    def __init__(self, message: str, code: str = "OUTPUT_PUBLISH_FAILED"):
+        super().__init__(message)
+        self.code = code
+
 
 @dataclass(frozen=True)
 class PublishedGeneration:
@@ -41,13 +45,14 @@ class OutputPublisher:
         renderers: dict[str, Callable[[Path], object]],
     ) -> PublishedGeneration:
         if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", run_id):
-            raise PublicationError("Invalid output generation identifier")
+            raise PublicationError("Invalid output generation identifier", "OUTPUT_CONTRACT_INVALID")
         if not renderers or any(name not in _ALLOWED for name in renderers):
-            raise PublicationError("Output artifact is not in the publication allowlist")
+            raise PublicationError("Output artifact is not in the publication allowlist", "OUTPUT_CONTRACT_INVALID")
         staging = self.internal / "staging" / f"{run_id}.tmp"
         generation = self.internal / "generations" / run_id
         if generation.exists():
             raise PublicationError("Output generation already exists")
+        phase = "render"
         try:
             if staging.exists():
                 shutil.rmtree(staging)
@@ -57,6 +62,7 @@ class OutputPublisher:
                 renderer(target)
                 self._validate(name, target)
             artifacts = tuple(self._reference(run_id, name, staging / name) for name in renderers)
+            phase = "publish"
             generation.parent.mkdir(parents=True, exist_ok=True)
             os.replace(staging, generation)
             pointer = {
@@ -78,17 +84,18 @@ class OutputPublisher:
         except Exception as exc:
             if staging.exists():
                 shutil.rmtree(staging, ignore_errors=True)
-            raise PublicationError("Output generation could not be rendered or published") from exc
+            code = "OUTPUT_RENDER_FAILED" if phase == "render" else "OUTPUT_PUBLISH_FAILED"
+            raise PublicationError("Output generation could not be rendered or published", code) from exc
 
     @staticmethod
     def _validate(name: str, path: Path) -> None:
         if not path.is_file():
-            raise PublicationError("Output renderer did not create its artifact")
+            raise PublicationError("Output renderer did not create its artifact", "OUTPUT_RENDER_FAILED")
         try:
             if name == "recommendations.json":
                 payload = json.loads(path.read_text(encoding="utf-8"))
                 if payload.get("schema_name") != "zotwatch-recommendations" or payload.get("schema_version") != 1:
-                    raise PublicationError("Recommendation output contract is invalid")
+                    raise PublicationError("Recommendation output contract is invalid", "OUTPUT_CONTRACT_INVALID")
             elif name == "feed.xml":
                 ElementTree.parse(path)
             else:
@@ -96,7 +103,7 @@ class OutputPublisher:
         except PublicationError:
             raise
         except Exception as exc:
-            raise PublicationError("Rendered output is invalid") from exc
+            raise PublicationError("Rendered output is invalid", "OUTPUT_CONTRACT_INVALID") from exc
 
     @staticmethod
     def _reference(run_id: str, name: str, path: Path) -> ArtifactReference:

--- a/zotwatch/results/recorder.py
+++ b/zotwatch/results/recorder.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+from uuid import uuid4
+
+from .errors import run_error
+from .models import ArtifactReference, RunManifest, RunResult, StageRecord
+
+
+PROFILE_STAGES = (
+    "config_validation", "credential_preflight", "zotero_sync", "computational_state",
+)
+WATCH_STAGES = PROFILE_STAGES + (
+    "candidate_fetch", "dedupe", "ranking", "output_render", "zotero_writeback",
+    "output_publish",
+)
+
+
+def utc_text() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+class RunRecorder:
+    def __init__(
+        self,
+        state_root: Path | str,
+        command: str,
+        *,
+        config_schema_version: int | None,
+        config_fingerprint_sha256: str | None,
+        run_id: str | None = None,
+    ):
+        self.state_root = Path(state_root)
+        self.command = command
+        self.run_id = run_id or uuid4().hex
+        self.generated_at = utc_text()
+        self.config_schema_version = config_schema_version
+        self.config_fingerprint = config_fingerprint_sha256
+        names = PROFILE_STAGES if command == "profile" else WATCH_STAGES
+        self.stages = {name: StageRecord(stage=name, status="pending") for name in names}
+
+    def start(self, stage: str) -> None:
+        self.stages[stage] = self.stages[stage].model_copy(
+            update={"status": "running", "started_at": utc_text()}
+        )
+
+    def finish(self, stage: str, *, count: int | None = None) -> None:
+        current = self.stages[stage]
+        self.stages[stage] = current.model_copy(update={
+            "status": "succeeded", "started_at": current.started_at or utc_text(),
+            "finished_at": utc_text(), "count": count,
+        })
+
+    def degrade(self, stage: str, code: str, *, count: int | None = None) -> None:
+        current = self.stages[stage]
+        self.stages[stage] = current.model_copy(update={
+            "status": "degraded", "started_at": current.started_at or utc_text(),
+            "finished_at": utc_text(), "count": count, "error": run_error(code),
+        })
+
+    def fail(self, stage: str, code: str) -> None:
+        current = self.stages[stage]
+        self.stages[stage] = current.model_copy(update={
+            "status": "failed", "started_at": current.started_at or utc_text(),
+            "finished_at": utc_text(), "error": run_error(code),
+        })
+
+    def finalize(
+        self,
+        *,
+        status: str,
+        exit_code: int,
+        error_code: str | None = None,
+        state_generation_id: str | None = None,
+        output_generation_id: str | None = None,
+        artifacts: tuple[ArtifactReference, ...] = (),
+    ) -> RunResult:
+        stages = []
+        for stage in self.stages.values():
+            if stage.status in {"pending", "running"}:
+                stage = stage.model_copy(update={"status": "skipped", "finished_at": utc_text()})
+            stages.append(stage)
+        error = run_error(error_code) if error_code else None
+        manifest = RunManifest(
+            run_id=self.run_id,
+            command=self.command,
+            status=status,
+            exit_code=exit_code,
+            generated_at=self.generated_at,
+            config_schema_version=self.config_schema_version,
+            config_fingerprint_sha256=self.config_fingerprint,
+            state_generation_id=state_generation_id,
+            output_generation_id=output_generation_id,
+            stages=stages,
+            artifacts=list(artifacts),
+            error=error,
+        )
+        relative = f"runs/{self.run_id}.json"
+        path = self.state_root / relative
+        self._atomic_json(path, manifest.model_dump(mode="json"))
+        self._atomic_json(
+            self.state_root / "runs/latest-attempt.json",
+            {"schema_version": 1, "run_id": self.run_id, "manifest_path": relative},
+        )
+        return RunResult(
+            run_id=self.run_id,
+            status=status,
+            exit_code=exit_code,
+            error=error,
+            manifest_path=relative,
+            state_generation_id=state_generation_id,
+            output_generation_id=output_generation_id,
+            artifacts=list(artifacts),
+        )
+
+    @staticmethod
+    def _atomic_json(path: Path, payload: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_name(f".{path.name}.tmp")
+        data = (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode()
+        with temporary.open("wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+
+
+__all__ = ["RunRecorder", "utc_text"]

--- a/zotwatch/runtime/preflight.py
+++ b/zotwatch/runtime/preflight.py
@@ -53,9 +53,7 @@ def preflight(
     verification: Literal["not_requested", "verified", "failed", "unsupported"] = "not_requested"
 
     error_code = None
-    if "json" in config.output_formats:
-        error_code = "OUTPUT_FORMAT_UNAVAILABLE"
-    elif any(route.adapter_status is not AdapterStatus.IMPLEMENTED for route in config.feature_routes):
+    if any(route.adapter_status is not AdapterStatus.IMPLEMENTED for route in config.feature_routes):
         error_code = "CAPABILITY_UNAVAILABLE"
     elif not identity_present or not key_present:
         error_code = "CREDENTIAL_MISSING"


### PR DESCRIPTION
E5B completes the engine contract needed before P2. Basic v2 watch runs now emit recommendation JSON v1, private run manifests, and optional machine RunResult JSON with stable stages, symbolic errors, and numeric exit categories. Recommendation score provenance exposes all seven additive legacy components without changing the formula or order; explicit public candidate preprint metadata is transported without inference.

Requested outputs render into staging, validate, become an immutable generation, and are selected by an atomic latest-success pointer. RunResult and the pointer expose only finalized generation-relative artifact references with hashes, sizes, media types, and publishability. Stable report paths remain compatibility aliases. Alias refresh failure after pointer commit cannot invalidate the authoritative generation; the next run reconciles aliases from the pointer. Candidate acquisition distinguishes complete empty, partial/stale degraded, and unavailable states; strict degradation does not publish.

No AI adapter/request, ranking formula, E3 sync behavior, E4 state semantics, public candidate protocol, reusable workflow, Cloudflare, workspace-template, or harvester code is included.

Validation:
- source suite: 207 passed, 16 packaging-only skipped
- forced wheel/editable suite: 223 passed
- wheel and editable `pip check`: clean
- E5A fixtures/goldens unchanged
- E0 fixtures/goldens not deleted, modified, or renamed